### PR TITLE
UI-Refresh

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,7 @@ android {
 
 dependencies {
     implementation(libs.core.ktx)
+    implementation(libs.core.splashscreen)
     implementation(libs.lifecycle.runtime.ktx)
     implementation(libs.activity.compose)
     implementation(platform(libs.compose.bom))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,7 +64,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.NotiTask"
+            android:theme="@style/Theme.NotiTask.Splash"
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/org/muilab/notigpt/MainActivity.kt
+++ b/app/src/main/java/org/muilab/notigpt/MainActivity.kt
@@ -9,10 +9,11 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
 import android.content.pm.PackageManager
@@ -54,6 +55,11 @@ class MainActivity : ComponentActivity() {
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Must precede super.onCreate: swaps the launch (splash) theme for the app theme.
+        installSplashScreen()
+        // Draw behind the system bars; enableEdgeToEdge also keeps status/nav icon contrast in sync
+        // with the light/dark mode. Compose consumes the insets via Scaffold + WindowInsets.
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         // WorkManager.getInstance(applicationContext).cancelAllWork()
@@ -109,11 +115,9 @@ class MainActivity : ComponentActivity() {
                 val extractionStatus by org.muilab.notigpt.data.remote.n8n.ExtractionStatusStore.status.collectAsState()
                 LaunchedEffect(extractionStatus.userTriggeredFailureTick) {
                     if (extractionStatus.userTriggeredFailureTick > 0L) {
-                        Toast.makeText(
-                            this@MainActivity,
-                            getString(R.string.extraction_failed_toast),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                        org.muilab.notigpt.ui.common.feedback.AppSnackbar.show(
+                            getString(R.string.extraction_failed_toast)
+                        )
                     }
                 }
                 Surface(

--- a/app/src/main/java/org/muilab/notigpt/ui/auth/SignInScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/auth/SignInScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -49,6 +50,7 @@ fun SignInScreen(onSignedIn: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .systemBarsPadding()
             .padding(32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/org/muilab/notigpt/ui/common/appbar/AppTopBar.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/appbar/AppTopBar.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -46,32 +47,51 @@ fun AppTopBar(
     searchQuery: String? = null,
     onSearchQueryChange: ((String) -> Unit)? = null,
     scrollBehavior: TopAppBarScrollBehavior? = null,
+    /** Render as a collapsing large-title bar (home root). Ignores search. */
+    large: Boolean = false,
     /** Screen-specific trailing actions (e.g. "Clear all"), shown to the right of search when not searching. */
     actions: @Composable RowScope.() -> Unit = {},
 ) {
+    val barColors = TopAppBarDefaults.topAppBarColors(
+        containerColor = MaterialTheme.colorScheme.surface,
+        scrolledContainerColor = MaterialTheme.colorScheme.surface,
+    )
+    val navIcon: @Composable () -> Unit = {
+        if (onNavigateBack != null) {
+            IconButton(
+                modifier = Modifier.minimumInteractiveComponentSize(),
+                onClick = onNavigateBack,
+            ) {
+                Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.a11y_back))
+            }
+        } else {
+            IconButton(
+                modifier = Modifier.minimumInteractiveComponentSize(),
+                onClick = onMenuClicked,
+            ) {
+                Icon(painter = painterResource(id = R.drawable.menu), contentDescription = stringResource(R.string.a11y_menu))
+            }
+        }
+    }
+
+    if (large) {
+        LargeTopAppBar(
+            scrollBehavior = scrollBehavior,
+            colors = TopAppBarDefaults.largeTopAppBarColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+                scrolledContainerColor = MaterialTheme.colorScheme.surface,
+            ),
+            navigationIcon = navIcon,
+            title = { Text(text = screenTitle ?: stringResource(R.string.app_name)) },
+            actions = actions,
+        )
+        return
+    }
+
     TopAppBar(
         scrollBehavior = scrollBehavior,
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-            scrolledContainerColor = MaterialTheme.colorScheme.surface,
-        ),
-        navigationIcon = {
-            if (onNavigateBack != null) {
-                IconButton(
-                    modifier = Modifier.minimumInteractiveComponentSize(),
-                    onClick = onNavigateBack,
-                ) {
-                    Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.a11y_back))
-                }
-            } else {
-                IconButton(
-                    modifier = Modifier.minimumInteractiveComponentSize(),
-                    onClick = onMenuClicked,
-                ) {
-                    Icon(painter = painterResource(id = R.drawable.menu), contentDescription = stringResource(R.string.a11y_menu))
-                }
-            }
-        },
+        colors = barColors,
+        navigationIcon = navIcon,
         title = {
             AnimatedContent(
                 targetState = isSearchExpanded && showSearch,

--- a/app/src/main/java/org/muilab/notigpt/ui/common/component/AppDrawerContent.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/component/AppDrawerContent.kt
@@ -1,13 +1,15 @@
 package org.muilab.notigpt.ui.common.component
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Badge
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.Text
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -16,11 +18,17 @@ import androidx.compose.ui.unit.dp
 import org.muilab.notigpt.R
 import org.muilab.notigpt.ui.common.navigation.AppMenuScreen
 import org.muilab.notigpt.ui.common.navigation.SavedListFilter
+import org.muilab.notigpt.ui.theme.Dimens
 
-/** Hamburger drawer content: back to the home overview plus the secondary app sections. */
+/**
+ * Hamburger drawer: an account header, then the home overview + Tasks/Keep collections, then the
+ * secondary sections. Each destination has a distinct icon (previously Tasks/Reminders/Preferences all
+ * reused the same glyph) and section labels group the two tiers.
+ */
 @Composable
 fun AppDrawerContent(
     isHome: Boolean,
+    accountEmail: String?,
     unresolvedConflictCount: Int,
     dueUnseenReminderCount: Int,
     activeTaskCount: Int,
@@ -30,42 +38,61 @@ fun AppDrawerContent(
     onMenuScreenSelected: (AppMenuScreen) -> Unit,
 ) {
     ModalDrawerSheet {
-        // The overview lives at the home root; the drawer just offers a way back to it plus the
-        // Tasks/Keep collections and the secondary sections (scheduled reminders, preferences,
-        // history, settings).
+        // Account header.
+        Column(modifier = Modifier.padding(horizontal = 28.dp, vertical = 24.dp)) {
+            Text(
+                text = stringResource(R.string.app_name),
+                style = MaterialTheme.typography.titleLarge,
+            )
+            if (!accountEmail.isNullOrBlank()) {
+                Text(
+                    text = accountEmail,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
         NavigationDrawerItem(
+            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
             label = { Text(stringResource(R.string.menu_home)) },
             icon = { Icon(painter = painterResource(R.drawable.home), contentDescription = null) },
             selected = isHome,
             onClick = onHomeSelected,
         )
+
+        DrawerSectionLabel(stringResource(R.string.menu_section_collections))
         // Tasks / Keep collections, with a live badge of the active (non-completed / non-archived) count.
         NavigationDrawerItem(
+            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
             label = { Text(stringResource(R.string.home_collection_tasks)) },
-            icon = { Icon(painter = painterResource(R.drawable.task), contentDescription = null) },
+            icon = { Icon(painter = painterResource(R.drawable.checklist), contentDescription = null) },
             badge = { if (activeTaskCount > 0) Text(activeTaskCount.toString()) },
             selected = false,
             onClick = { onSavedListSelected(SavedListFilter.Tasks) },
         )
         NavigationDrawerItem(
+            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
             label = { Text(stringResource(R.string.home_collection_keep)) },
-            icon = { Icon(painter = painterResource(R.drawable.keep), contentDescription = null) },
+            icon = { Icon(painter = painterResource(R.drawable.bookmark), contentDescription = null) },
             badge = { if (activeKeepCount > 0) Text(activeKeepCount.toString()) },
             selected = false,
             onClick = { onSavedListSelected(SavedListFilter.Keep) },
         )
 
         HorizontalDivider(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp),
             color = MaterialTheme.colorScheme.outlineVariant,
         )
 
+        DrawerSectionLabel(stringResource(R.string.menu_section_more))
         NavigationDrawerItem(
+            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
             label = { Text(stringResource(R.string.menu_reminders)) },
-            icon = { Icon(painter = painterResource(R.drawable.task), contentDescription = null) },
+            icon = { Icon(painter = painterResource(R.drawable.schedule), contentDescription = null) },
             badge = {
                 if (dueUnseenReminderCount > 0) {
-                    Badge(containerColor = androidx.compose.ui.graphics.Color.Red) {
+                    Badge(containerColor = MaterialTheme.colorScheme.error) {
                         Text(dueUnseenReminderCount.toString())
                     }
                 }
@@ -74,8 +101,10 @@ fun AppDrawerContent(
             onClick = { onMenuScreenSelected(AppMenuScreen.Reminders) },
         )
         NavigationDrawerItem(
+            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
             label = { Text(stringResource(R.string.tab_preferences)) },
-            icon = { Icon(painter = painterResource(R.drawable.task), contentDescription = null) },
+            // TODO(icon): replace `info` placeholder with a `tune` glyph (see icon request list).
+            icon = { Icon(painter = painterResource(R.drawable.info), contentDescription = null) },
             badge = {
                 if (unresolvedConflictCount > 0) {
                     Badge { Text(unresolvedConflictCount.toString()) }
@@ -85,16 +114,28 @@ fun AppDrawerContent(
             onClick = { onMenuScreenSelected(AppMenuScreen.Preferences) },
         )
         NavigationDrawerItem(
+            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
             label = { Text(stringResource(R.string.menu_history)) },
             icon = { Icon(painter = painterResource(R.drawable.notifications), contentDescription = null) },
             selected = false,
             onClick = { onMenuScreenSelected(AppMenuScreen.History) },
         )
         NavigationDrawerItem(
+            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
             label = { Text(stringResource(R.string.menu_settings)) },
             icon = { Icon(painter = painterResource(R.drawable.settings), contentDescription = null) },
             selected = false,
             onClick = { onMenuScreenSelected(AppMenuScreen.Settings) },
         )
     }
+}
+
+@Composable
+private fun DrawerSectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 28.dp, end = 28.dp, top = Dimens.element, bottom = 4.dp),
+    )
 }

--- a/app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt
@@ -3,13 +3,21 @@ package org.muilab.notigpt.ui.common.component
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
-import androidx.activity.compose.BackHandler
+import androidx.activity.compose.PredictiveBackHandler
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -66,6 +74,19 @@ import org.muilab.notigpt.ui.preference.viewmodel.PreferenceViewModel
 import org.muilab.notigpt.ui.review.ReviewScreen
 import org.muilab.notigpt.ui.reminder.viewmodel.ReminderViewModel
 import org.muilab.notigpt.ui.reminder.viewmodel.ScheduledReminderViewModel
+import org.muilab.notigpt.ui.theme.MotionSpecs
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Immutable snapshot of the current navigation position, used as the [AnimatedContent] key so the
+ * outgoing and incoming screens each render from their own state during a transition. [depth]
+ * (back-stack size, +1 while a menu screen is open) drives push-vs-pop direction.
+ */
+private data class NavSnapshot(
+    val menuScreen: AppMenuScreen?,
+    val dest: HomeDestination,
+    val depth: Int,
+)
 
 /**
  * Top-level Compose scaffold that places app bars, navigation, and the selected screen content.
@@ -95,12 +116,20 @@ fun AppScaffold(
 
     // A task/keep detail editor is open → hide the app bars (full-screen detail).
     var detailOpen by remember { mutableStateOf(false) }
-    // Collapse the top bar in step with scrolling — only on the list-style screens.
-    val barsScrollEnabled = menuScreen == AppMenuScreen.History ||
+    // The home root uses a collapsing large-title bar; list screens use an enter-always small bar;
+    // everything else has a pinned small bar (no scroll behavior).
+    val listScrollEnabled = menuScreen == AppMenuScreen.History ||
         menuScreen == AppMenuScreen.Reminders ||
         (menuScreen == null && (currentDest is HomeDestination.SavedList || currentDest is HomeDestination.NotiList))
     val topBarState = rememberTopAppBarState()
-    val topBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topBarState)
+    // Both behaviors share topBarState; only the active one is attached to the Scaffold's nestedScroll.
+    val exitUntilCollapsed = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topBarState)
+    val enterAlways = TopAppBarDefaults.enterAlwaysScrollBehavior(topBarState)
+    val topBarScrollBehavior = when {
+        atHomeRoot -> exitUntilCollapsed
+        listScrollEnabled -> enterAlways
+        else -> null
+    }
     LaunchedEffect(currentDest, menuScreen) {
         topBarState.heightOffset = 0f
         topBarState.contentOffset = 0f
@@ -247,8 +276,18 @@ fun AppScaffold(
         if (backStack.size > 1) backStack.removeAt(backStack.lastIndex)
     }
 
-    BackHandler(enabled = menuScreen != null || backStack.size > 1) {
-        if (menuScreen != null) menuScreen = null else popBack()
+    // Predictive back: scrub a subtle scale on the content during the gesture, commit the pop on
+    // completion (which then plays the AnimatedContent pop), and spring back on cancel.
+    var backProgress by remember { mutableStateOf(0f) }
+    PredictiveBackHandler(enabled = menuScreen != null || backStack.size > 1) { events ->
+        try {
+            events.collect { event -> backProgress = event.progress }
+            backProgress = 0f
+            if (menuScreen != null) menuScreen = null else popBack()
+        } catch (e: CancellationException) {
+            backProgress = 0f
+            throw e
+        }
     }
 
     // ── Top-bar configuration for the current destination ──
@@ -272,6 +311,7 @@ fun AppScaffold(
         drawerContent = {
             AppDrawerContent(
                 isHome = atHomeRoot,
+                accountEmail = org.muilab.notigpt.data.remote.auth.GoogleAuthManager.currentUser()?.email,
                 unresolvedConflictCount = unresolvedConflicts.size,
                 dueUnseenReminderCount = dueUnseenReminderCount,
                 activeTaskCount = activeTaskCount,
@@ -283,7 +323,7 @@ fun AppScaffold(
         },
     ) {
         Scaffold(
-            modifier = if (barsScrollEnabled) {
+            modifier = if (topBarScrollBehavior != null) {
                 Modifier.nestedScroll(topBarScrollBehavior.nestedScrollConnection)
             } else Modifier,
             topBar = {
@@ -304,7 +344,8 @@ fun AppScaffold(
                         showSearch = showSearch,
                         searchQuery = appSearchQuery,
                         onSearchQueryChange = drawerViewModel::updateQueryString,
-                        scrollBehavior = if (barsScrollEnabled) topBarScrollBehavior else null,
+                        scrollBehavior = topBarScrollBehavior,
+                        large = atHomeRoot,
                         actions = {
                             // Clear-all bin on the notification category (Communication/Content) pages.
                             // Scoped to the visible list: the current category + time window, excluding pinned.
@@ -329,61 +370,89 @@ fun AppScaffold(
                 }
             },
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-            containerColor = MaterialTheme.colorScheme.surfaceDim,
+            // Canvas: the lightest surface; cards (surfaceContainerLow / surfaceBright) provide
+            // subtle separation. See the surface-role note in Color.kt.
+            containerColor = MaterialTheme.colorScheme.surface,
         ) { paddingValues ->
-            Box(
-                modifier = Modifier.padding(paddingValues)
-            ) {
-                when (val screen = menuScreen) {
-                    AppMenuScreen.Reminders -> ScheduledRemindersScreen(
-                        viewModel = scheduledReminderViewModel,
-                        searchQuery = appSearchQuery,
-                    )
-                    AppMenuScreen.Preferences -> PreferenceChatScreen(
-                        preferenceViewModel = preferenceViewModel,
-                    )
-                    AppMenuScreen.History -> NotificationHistoryScreen(
-                        drawerViewModel = drawerViewModel,
-                        searchQuery = appSearchQuery,
-                    )
-                    AppMenuScreen.Settings -> SettingsScreen()
-                    null -> when (val dest = currentDest) {
-                        HomeDestination.Home -> HomeScreen(
-                            drawerViewModel = drawerViewModel,
-                            onOpenReview = { pushHome(HomeDestination.Review) },
-                            onOpenNotiCategory = { category -> pushHome(HomeDestination.NotiList(category)) },
-                            onOpenSavedList = { filter -> pushHome(HomeDestination.SavedList(filter)) },
-                        )
-                        HomeDestination.Review -> ReviewScreen(
-                            drawerViewModel = drawerViewModel,
-                            reminderViewModel = reminderViewModel,
-                            onBack = popBack,
-                        )
-                        is HomeDestination.NotiList -> NotiCategoryScreen(
-                            category = dest.category,
-                            drawerViewModel = drawerViewModel,
-                            scheduledReminderViewModel = scheduledReminderViewModel,
+            val navDepth = backStack.size + (if (menuScreen != null) 1 else 0)
+            val navSnapshot = NavSnapshot(menuScreen, currentDest, navDepth)
+            AnimatedContent(
+                targetState = navSnapshot,
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .graphicsLayer {
+                        val s = 1f - 0.06f * backProgress.coerceIn(0f, 1f)
+                        scaleX = s
+                        scaleY = s
+                    },
+                transitionSpec = {
+                    val ms = MotionSpecs.ScreenTransitionMs
+                    val menuInvolved = initialState.menuScreen != null || targetState.menuScreen != null
+                    when {
+                        menuInvolved ->
+                            fadeIn(tween(ms)) togetherWith fadeOut(tween(ms))
+                        targetState.depth >= initialState.depth ->
+                            (slideInHorizontally(tween(ms)) { it / 4 } + fadeIn(tween(ms))) togetherWith
+                                (slideOutHorizontally(tween(ms)) { -it / 6 } + fadeOut(tween(ms)))
+                        else ->
+                            (slideInHorizontally(tween(ms)) { -it / 6 } + fadeIn(tween(ms))) togetherWith
+                                (slideOutHorizontally(tween(ms)) { it / 4 } + fadeOut(tween(ms)))
+                    }
+                },
+                label = "screen",
+            ) { snap ->
+                Box(Modifier.fillMaxSize()) {
+                    when (snap.menuScreen) {
+                        AppMenuScreen.Reminders -> ScheduledRemindersScreen(
+                            viewModel = scheduledReminderViewModel,
                             searchQuery = appSearchQuery,
                         )
-                        is HomeDestination.SavedList -> {
-                            val listMode = when (dest.filter) {
-                                SavedListFilter.Tasks -> ReminderViewModel.ListMode.Tasks
-                                SavedListFilter.Keep -> ReminderViewModel.ListMode.Keep
-                                else -> ReminderViewModel.ListMode.All
-                            }
-                            val smart = when (dest.filter) {
-                                SavedListFilter.Tasks, SavedListFilter.Keep -> null
-                                else -> dest.filter
-                            }
-                            RemindersScreen(
+                        AppMenuScreen.Preferences -> PreferenceChatScreen(
+                            preferenceViewModel = preferenceViewModel,
+                        )
+                        AppMenuScreen.History -> NotificationHistoryScreen(
+                            drawerViewModel = drawerViewModel,
+                            searchQuery = appSearchQuery,
+                        )
+                        AppMenuScreen.Settings -> SettingsScreen()
+                        null -> when (val dest = snap.dest) {
+                            HomeDestination.Home -> HomeScreen(
+                                drawerViewModel = drawerViewModel,
+                                onOpenReview = { pushHome(HomeDestination.Review) },
+                                onOpenNotiCategory = { category -> pushHome(HomeDestination.NotiList(category)) },
+                                onOpenSavedList = { filter -> pushHome(HomeDestination.SavedList(filter)) },
+                            )
+                            HomeDestination.Review -> ReviewScreen(
                                 drawerViewModel = drawerViewModel,
                                 reminderViewModel = reminderViewModel,
-                                scheduledReminderViewModel = scheduledReminderViewModel,
-                                preferenceViewModel = preferenceViewModel,
-                                listMode = listMode,
-                                smartFilter = smart,
-                                onDetailOpenChange = { detailOpen = it },
+                                onBack = popBack,
                             )
+                            is HomeDestination.NotiList -> NotiCategoryScreen(
+                                category = dest.category,
+                                drawerViewModel = drawerViewModel,
+                                scheduledReminderViewModel = scheduledReminderViewModel,
+                                searchQuery = appSearchQuery,
+                            )
+                            is HomeDestination.SavedList -> {
+                                val listMode = when (dest.filter) {
+                                    SavedListFilter.Tasks -> ReminderViewModel.ListMode.Tasks
+                                    SavedListFilter.Keep -> ReminderViewModel.ListMode.Keep
+                                    else -> ReminderViewModel.ListMode.All
+                                }
+                                val smart = when (dest.filter) {
+                                    SavedListFilter.Tasks, SavedListFilter.Keep -> null
+                                    else -> dest.filter
+                                }
+                                RemindersScreen(
+                                    drawerViewModel = drawerViewModel,
+                                    reminderViewModel = reminderViewModel,
+                                    scheduledReminderViewModel = scheduledReminderViewModel,
+                                    preferenceViewModel = preferenceViewModel,
+                                    listMode = listMode,
+                                    smartFilter = smart,
+                                    onDetailOpenChange = { detailOpen = it },
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt
@@ -19,9 +19,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
@@ -116,6 +118,8 @@ fun AppScaffold(
 
     // A task/keep detail editor is open → hide the app bars (full-screen detail).
     var detailOpen by remember { mutableStateOf(false) }
+    // Category pending "clear all" confirmation (the clear is a hard delete, so we confirm first).
+    var clearConfirmCategory by remember { mutableStateOf<String?>(null) }
     // The home root uses a collapsing large-title bar; list screens use an enter-always small bar;
     // everything else has a pinned small bar (no scroll behavior).
     val listScrollEnabled = menuScreen == AppMenuScreen.History ||
@@ -356,7 +360,7 @@ fun AppScaffold(
                                 val enabled = clearableCount > 0
                                 IconButton(
                                     enabled = enabled,
-                                    onClick = { drawerViewModel.clearVisibleNotis(category) },
+                                    onClick = { clearConfirmCategory = category },
                                 ) {
                                     Icon(
                                         painter = painterResource(R.drawable.delete),
@@ -458,6 +462,30 @@ fun AppScaffold(
                 }
             }
         }
+    }
+
+    clearConfirmCategory?.let { category ->
+        AlertDialog(
+            onDismissRequest = { clearConfirmCategory = null },
+            title = { Text(stringResource(R.string.noti_clear_all_confirm_title)) },
+            text = { Text(stringResource(R.string.noti_clear_all_confirm_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    drawerViewModel.clearVisibleNotis(category)
+                    clearConfirmCategory = null
+                }) {
+                    Text(
+                        stringResource(R.string.ui_user_clear_all),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { clearConfirmCategory = null }) {
+                    Text(stringResource(R.string.ui_action_cancel))
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt
@@ -47,6 +47,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import org.muilab.notigpt.R
 import org.muilab.notigpt.model.features.NotiCategory
 import org.muilab.notigpt.ui.preference.model.PreferenceEntryPoint
+import org.muilab.notigpt.ui.common.feedback.AppSnackbar
 import org.muilab.notigpt.ui.common.appbar.AppTopBar
 import org.muilab.notigpt.ui.home.HomeScreen
 import org.muilab.notigpt.ui.home.viewmodel.HomeViewModel
@@ -150,6 +151,18 @@ fun AppScaffold(
                 SnackbarResult.ActionPerformed -> preferenceViewModel.promoteSnackbarToFlow(event)
                 SnackbarResult.Dismissed -> { /* already cleared */ }
             }
+        }
+    }
+
+    // App-wide status messages (replaces scattered Toasts). Emitted via AppSnackbar from UI or VMs.
+    LaunchedEffect(Unit) {
+        AppSnackbar.messages.collect { msg ->
+            val result = snackbarHostState.showSnackbar(
+                message = msg.text,
+                actionLabel = msg.actionLabel,
+                duration = SnackbarDuration.Short,
+            )
+            if (result == SnackbarResult.ActionPerformed) msg.onAction?.invoke()
         }
     }
 

--- a/app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt
@@ -425,6 +425,8 @@ fun AppScaffold(
                                 onOpenReview = { pushHome(HomeDestination.Review) },
                                 onOpenNotiCategory = { category -> pushHome(HomeDestination.NotiList(category)) },
                                 onOpenSavedList = { filter -> pushHome(HomeDestination.SavedList(filter)) },
+                                dueReminderCount = dueUnseenReminderCount,
+                                onOpenReminders = { openMenuScreen(AppMenuScreen.Reminders) },
                             )
                             HomeDestination.Review -> ReviewScreen(
                                 drawerViewModel = drawerViewModel,

--- a/app/src/main/java/org/muilab/notigpt/ui/common/component/DevControlPanel.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/component/DevControlPanel.kt
@@ -1,7 +1,6 @@
 package org.muilab.notigpt.ui.common.component
 
 import android.content.Context
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -21,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.muilab.notigpt.R
+import org.muilab.notigpt.ui.common.feedback.AppSnackbar
 import org.muilab.notigpt.ui.notification.component.AutoControlBar
 import org.muilab.notigpt.ui.notification.viewmodel.DrawerViewModel
 import org.muilab.notigpt.util.SharedPreferencesManager
@@ -65,12 +65,12 @@ fun DevControlPanel(context: Context, drawerViewModel: DrawerViewModel) {
 
                 AutoControlBar()
                 Button(onClick = {
-                    Toast.makeText(context, context.getString(R.string.ui_dev_sync_noti_status_toast), Toast.LENGTH_SHORT).show()
+                    AppSnackbar.show(context.getString(R.string.ui_dev_sync_noti_status_toast))
                 }) {
                     Text(stringResource(R.string.ui_dev_sync_noti_status))
                 }
                 Button(onClick = {
-                    Toast.makeText(context, context.getString(R.string.ui_dev_work_in_progress), Toast.LENGTH_SHORT).show()
+                    AppSnackbar.show(context.getString(R.string.ui_dev_work_in_progress))
                 }) {
                     Text(stringResource(R.string.ui_dev_update_user))
                 }
@@ -94,13 +94,11 @@ fun DevControlPanel(context: Context, drawerViewModel: DrawerViewModel) {
                         SharedPreferencesManager.init(context.applicationContext)
                         ReminderPeriodicWork.logStatus(context.applicationContext)
                         val t = SharedPreferencesManager.lastReminderPeriodicRunTime
-                        Toast.makeText(
-                            context,
-                            if (t == 0L) "Periodic worker hasn't run yet (or prefs cleared)" else "Last periodic run: $t",
-                            Toast.LENGTH_LONG
-                        ).show()
+                        AppSnackbar.show(
+                            if (t == 0L) "Periodic worker hasn't run yet (or prefs cleared)" else "Last periodic run: $t"
+                        )
                     } catch (e: Exception) {
-                        Toast.makeText(context, "Failed to query periodic work: ${e.message}", Toast.LENGTH_LONG).show()
+                        AppSnackbar.show("Failed to query periodic work: ${e.message}")
                     }
                 }) {
                     Text("Debug: periodic work status")

--- a/app/src/main/java/org/muilab/notigpt/ui/common/component/DueChip.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/component/DueChip.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -76,7 +75,7 @@ fun DueChip(
 
     Row(
         modifier = modifier
-            .clip(RoundedCornerShape(8.dp))
+            .clip(MaterialTheme.shapes.small)
             .background(container)
             .padding(horizontal = 8.dp, vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -124,7 +123,7 @@ fun DoDateChip(
 
     Row(
         modifier = modifier
-            .clip(RoundedCornerShape(8.dp))
+            .clip(MaterialTheme.shapes.small)
             .background(container)
             .padding(horizontal = 8.dp, vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/org/muilab/notigpt/ui/common/component/SearchBar.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/component/SearchBar.kt
@@ -1,26 +1,24 @@
 package org.muilab.notigpt.ui.common.component
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -28,14 +26,16 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.LaunchedEffect
 import org.muilab.notigpt.R
 import org.muilab.notigpt.ui.notification.viewmodel.DrawerViewModel
 
 /**
  * Shared Compose search field used by drawer/reminder screens.
  *
- * Keep this component presentation-only. Query interpretation, debouncing, and persistence should remain in the
- * calling screen or ViewModel.
+ * A borderless filled pill (no indicator lines) that auto-focuses and raises the keyboard when it
+ * appears. The trailing button clears the query, or closes search when the query is already empty.
+ * Keep this component presentation-only — query interpretation stays in the caller/ViewModel.
  */
 @Composable
 fun SearchBar(
@@ -50,43 +50,61 @@ fun SearchBar(
 
     val keyboardController = LocalSoftwareKeyboardController.current
     val currentFocus = LocalFocusManager.current
+    val focusRequester = remember { FocusRequester() }
 
-    Column(Modifier.fillMaxWidth()) {
-        Row(
+    // Raise focus + keyboard as the field appears.
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Row(modifier = Modifier.fillMaxWidth().padding(end = 4.dp)) {
+        TextField(
+            value = queryString,
+            onValueChange = { updateQueryString(it) },
+            placeholder = {
+                Text(
+                    text = stringResource(R.string.ui_search_placeholder),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            textStyle = MaterialTheme.typography.bodyLarge,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 15.dp)
-        ) {
-            OutlinedTextField(
-                value = queryString,
-                onValueChange = { updateQueryString(it) },
-                placeholder = { Text(stringResource(R.string.ui_search_placeholder)) },
-                modifier = Modifier.fillMaxWidth().minimumInteractiveComponentSize(),
-                shape = RoundedCornerShape(percent = 100),
-                leadingIcon = { Icon(painterResource(R.drawable.search), contentDescription = null) },
-                trailingIcon = {
-                    IconButton(
-                        onClick = {
-                            updateQueryString("")
-                            onSearchToggled(false)
-                        }
-                    ) {
-                        Icon(painterResource(R.drawable.close), contentDescription = stringResource(R.string.a11y_close_search))
-                    }
-                },
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(onDone = {
-                    keyboardController?.hide()
-                    currentFocus.clearFocus()
-                }),
-                singleLine = true,
-                colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedIndicatorColor = MaterialTheme.colorScheme.primary,
-                    unfocusedIndicatorColor = MaterialTheme.colorScheme.outline
+                .focusRequester(focusRequester)
+                .minimumInteractiveComponentSize(),
+            shape = MaterialTheme.shapes.large,
+            leadingIcon = {
+                Icon(
+                    painterResource(R.drawable.search),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-            )
-        }
+            },
+            trailingIcon = {
+                IconButton(
+                    onClick = {
+                        if (queryString.isEmpty()) onSearchToggled(false) else updateQueryString("")
+                    }
+                ) {
+                    Icon(
+                        painterResource(R.drawable.close),
+                        contentDescription = stringResource(R.string.a11y_close_search),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = {
+                keyboardController?.hide()
+                currentFocus.clearFocus()
+            }),
+            singleLine = true,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                disabledIndicatorColor = Color.Transparent,
+            ),
+        )
     }
 }

--- a/app/src/main/java/org/muilab/notigpt/ui/common/component/UserControlPanel.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/component/UserControlPanel.kt
@@ -1,7 +1,6 @@
 package org.muilab.notigpt.ui.common.component
 
 import android.os.Build
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Row
@@ -16,6 +15,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.muilab.notigpt.R
+import org.muilab.notigpt.ui.common.feedback.AppSnackbar
 import org.muilab.notigpt.ui.notification.viewmodel.DrawerViewModel
 
 /**
@@ -39,7 +39,7 @@ fun UserControlPanel(drawerViewModel: DrawerViewModel) {
         TextButton(
             onClick = {
                 drawerViewModel.deleteAllNotis()
-                Toast.makeText(context, context.getString(R.string.ui_user_all_notifications_deleted), Toast.LENGTH_SHORT).show()
+                AppSnackbar.show(context.getString(R.string.ui_user_all_notifications_deleted))
             },
         ) {
             Text(stringResource(R.string.ui_user_clear_all))

--- a/app/src/main/java/org/muilab/notigpt/ui/common/feedback/AppSnackbar.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/feedback/AppSnackbar.kt
@@ -1,0 +1,38 @@
+package org.muilab.notigpt.ui.common.feedback
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * A single, one-line status message to surface as a Material snackbar.
+ *
+ * Text is pre-resolved by the caller (composables via `stringResource`, ViewModels via
+ * `getApplication().getString`) so the bus stays context-free.
+ */
+data class AppSnackbarMessage(
+    val text: String,
+    val actionLabel: String? = null,
+    val onAction: (() -> Unit)? = null,
+)
+
+/**
+ * Process-wide bus for transient status messages, replacing scattered `Toast`s.
+ *
+ * The app is single-activity; [org.muilab.notigpt.ui.common.component.AppScaffold] collects [messages]
+ * and shows them on its shared `SnackbarHostState`. Emit from anywhere — UI or ViewModel — via [show].
+ * Messages emitted while no collector is active (e.g. on the sign-in gate) are simply dropped, which is
+ * the right behaviour for ephemeral status.
+ */
+object AppSnackbar {
+    private val _messages = MutableSharedFlow<AppSnackbarMessage>(extraBufferCapacity = 16)
+    val messages: SharedFlow<AppSnackbarMessage> = _messages.asSharedFlow()
+
+    fun show(text: String) {
+        _messages.tryEmit(AppSnackbarMessage(text))
+    }
+
+    fun show(message: AppSnackbarMessage) {
+        _messages.tryEmit(message)
+    }
+}

--- a/app/src/main/java/org/muilab/notigpt/ui/common/feedback/Haptics.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/feedback/Haptics.kt
@@ -1,0 +1,29 @@
+package org.muilab.notigpt.ui.common.feedback
+
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+
+/**
+ * Semantic haptic wrappers over [HapticFeedback].
+ *
+ * Callers express intent ("a toggle just flipped", "a swipe committed") rather than picking a raw
+ * [HapticFeedbackType], so the feel stays consistent app-wide and can be retuned in one place. Obtain
+ * a [HapticFeedback] via `LocalHapticFeedback.current` and call these.
+ */
+object Haptics {
+    /** A binary control flipped (checkbox, star, archive, pin). */
+    fun toggle(h: HapticFeedback, on: Boolean) =
+        h.performHapticFeedback(if (on) HapticFeedbackType.ToggleOn else HapticFeedbackType.ToggleOff)
+
+    /** A drag crossed a commit threshold (review swipe, expand snap point) — light tick. */
+    fun thresholdCross(h: HapticFeedback) =
+        h.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
+
+    /** A gesture committed to a destructive/irreversible action (archive/dismiss swipe). */
+    fun commit(h: HapticFeedback) =
+        h.performHapticFeedback(HapticFeedbackType.Confirm)
+
+    /** Long-press recognised (card options, reorder pickup). */
+    fun longPress(h: HapticFeedback) =
+        h.performHapticFeedback(HapticFeedbackType.LongPress)
+}

--- a/app/src/main/java/org/muilab/notigpt/ui/common/feedback/UserToaster.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/common/feedback/UserToaster.kt
@@ -15,6 +15,17 @@ interface UserToaster {
     fun showShort(message: String, duration: Long = 1_000L)
 }
 
+/**
+ * Default [UserToaster] that routes messages to the app-wide [AppSnackbar] bus (shown as Material
+ * snackbars by AppScaffold). Preferred over [ToastUserToaster] so ViewModel status messages match the
+ * rest of the app's feedback. Context-free; [duration] is ignored (snackbars use their own timing).
+ */
+class SnackbarUserToaster : UserToaster {
+    override fun showShort(message: String, duration: Long) {
+        AppSnackbar.show(message)
+    }
+}
+
 class ToastUserToaster(context: Context) : UserToaster {
 
     // Use applicationContext to avoid leaking an Activity

--- a/app/src/main/java/org/muilab/notigpt/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/home/HomeScreen.kt
@@ -4,16 +4,18 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -27,7 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -40,6 +41,8 @@ import org.muilab.notigpt.ui.home.viewmodel.CategoryPreviewLine
 import org.muilab.notigpt.ui.home.viewmodel.HomeViewModel
 import org.muilab.notigpt.ui.home.viewmodel.ReviewCounts
 import org.muilab.notigpt.ui.notification.viewmodel.DrawerViewModel
+import org.muilab.notigpt.ui.theme.Dimens
+import org.muilab.notigpt.ui.theme.NotiType
 import org.muilab.notigpt.ui.theme.NotiTheme
 
 /**
@@ -48,6 +51,9 @@ import org.muilab.notigpt.ui.theme.NotiTheme
  * Ordered by the user's real workflow: (1) review new/updated generated items, (2) check recent
  * notifications by category, (3) browse saved items via planned-date smart filters and the
  * Tasks/Keep collections.
+ *
+ * Visual system (Apple-restraint): a single tinted hero (the Review row); everything else is a
+ * neutral card whose meaning comes from a small colored icon disc and a bold count.
  */
 @RequiresApi(Build.VERSION_CODES.S)
 @Composable
@@ -71,7 +77,7 @@ fun HomeScreen(
 
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(top = 8.dp, bottom = 24.dp),
     ) {
         item {
             ReviewRow(counts = reviewCounts, onClick = onOpenReview)
@@ -115,23 +121,29 @@ private fun HomeSectionHeader(title: String) {
         text = title,
         style = MaterialTheme.typography.titleSmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 8.dp),
+        modifier = Modifier.padding(
+            start = 20.dp,
+            end = 20.dp,
+            top = Dimens.sectionTop,
+            bottom = Dimens.sectionHeaderBottom,
+        ),
     )
 }
 
 @Composable
 private fun ReviewRow(counts: ReviewCounts, onClick: () -> Unit) {
     val summary = reviewSummary(counts)
+    // The screen's single tinted hero.
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = Dimens.screenH, vertical = Dimens.inline)
             .clickable(enabled = counts.total > 0, onClick = onClick),
-        shape = RoundedCornerShape(16.dp),
+        shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.primaryContainer,
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+            modifier = Modifier.padding(20.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
@@ -144,8 +156,7 @@ private fun ReviewRow(counts: ReviewCounts, onClick: () -> Unit) {
             Column(Modifier.weight(1f)) {
                 Text(
                     text = stringResource(R.string.home_review_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
+                    style = NotiType.cardTitle,
                     color = MaterialTheme.colorScheme.onPrimaryContainer,
                 )
                 Text(
@@ -183,13 +194,15 @@ private fun NotiCategoryRow(iconRes: Int, title: String, preview: CategoryPrevie
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .padding(horizontal = Dimens.screenH, vertical = Dimens.cardOuterV)
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(14.dp),
+        shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surfaceContainerLow,
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            modifier = Modifier
+                .heightIn(min = 72.dp)
+                .padding(horizontal = Dimens.cardInner, vertical = 14.dp),
             verticalAlignment = Alignment.Top,
         ) {
             Icon(
@@ -200,7 +213,7 @@ private fun NotiCategoryRow(iconRes: Int, title: String, preview: CategoryPrevie
             )
             Spacer(Modifier.size(16.dp))
             Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(text = title, style = MaterialTheme.typography.titleMedium)
+                Text(text = title, style = NotiType.cardTitle)
                 if (preview.topLines.isEmpty()) {
                     Text(
                         text = stringResource(R.string.home_noti_none),
@@ -251,23 +264,25 @@ private fun SmartFilterGrid(
     onOpen: (SavedListFilter) -> Unit,
 ) {
     Column(
-        modifier = Modifier.padding(horizontal = 16.dp),
+        modifier = Modifier.padding(horizontal = Dimens.screenH),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             SmartFilterBox(
                 count = counts.todayEarlier,
                 label = stringResource(R.string.home_filter_today),
-                container = NotiTheme.semantic.taskContainer,
-                content = NotiTheme.semantic.onTaskContainer,
+                iconRes = R.drawable.ic_calendar_today,
+                discContainer = NotiTheme.semantic.taskContainer,
+                discContent = NotiTheme.semantic.taskAccent,
                 onClick = { onOpen(SavedListFilter.TodayEarlier) },
                 modifier = Modifier.weight(1f),
             )
             SmartFilterBox(
                 count = counts.upcoming,
                 label = stringResource(R.string.home_filter_upcoming),
-                container = NotiTheme.semantic.keepContainer,
-                content = NotiTheme.semantic.onKeepContainer,
+                iconRes = R.drawable.schedule,
+                discContainer = NotiTheme.semantic.keepContainer,
+                discContent = NotiTheme.semantic.keepAccent,
                 onClick = { onOpen(SavedListFilter.Upcoming) },
                 modifier = Modifier.weight(1f),
             )
@@ -276,27 +291,30 @@ private fun SmartFilterGrid(
             SmartFilterBox(
                 count = counts.someday,
                 label = stringResource(R.string.home_filter_someday),
-                container = MaterialTheme.colorScheme.surfaceContainerHighest,
-                content = MaterialTheme.colorScheme.onSurface,
+                iconRes = R.drawable.inbox,
+                discContainer = MaterialTheme.colorScheme.surfaceContainerHighest,
+                discContent = MaterialTheme.colorScheme.onSurfaceVariant,
                 onClick = { onOpen(SavedListFilter.Someday) },
                 modifier = Modifier.weight(1f),
             )
             SmartFilterBox(
                 count = counts.starred,
                 label = stringResource(R.string.home_filter_starred),
-                container = NotiTheme.semantic.dueSoonContainer,
-                content = NotiTheme.semantic.onDueSoonContainer,
+                iconRes = R.drawable.star_yes,
+                discContainer = NotiTheme.semantic.dueSoonContainer,
+                discContent = NotiTheme.semantic.dueSoon,
                 onClick = { onOpen(SavedListFilter.Starred) },
                 modifier = Modifier.weight(1f),
             )
         }
-        // Undetermined is the large unplanned-triage pool; give it its own full-width box, still a box
-        // (not a collection row) so it reads as a smart filter. Task-only, so it skips the type split.
+        // Undetermined is the large unplanned-triage pool; a full-width box, still a box (not a
+        // collection row) so it reads as a smart filter. Task-only, so it skips the type split.
         SmartFilterBox(
             count = counts.undetermined,
             label = stringResource(R.string.home_filter_undetermined),
-            container = MaterialTheme.colorScheme.surfaceContainerHigh,
-            content = MaterialTheme.colorScheme.onSurfaceVariant,
+            iconRes = R.drawable.assignment_late,
+            discContainer = MaterialTheme.colorScheme.surfaceContainerHighest,
+            discContent = MaterialTheme.colorScheme.onSurfaceVariant,
             onClick = { onOpen(SavedListFilter.Undetermined) },
             modifier = Modifier.fillMaxWidth(),
             fullWidth = true,
@@ -308,33 +326,35 @@ private fun SmartFilterGrid(
 private fun SmartFilterBox(
     count: org.muilab.notigpt.data.local.room.dao.BucketCount,
     label: String,
-    container: Color,
-    content: Color,
+    iconRes: Int,
+    discContainer: Color,
+    discContent: Color,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     fullWidth: Boolean = false,
 ) {
+    // Neutral body; meaning carried by the colored disc + count.
     Surface(
         modifier = modifier
-            .then(if (fullWidth) Modifier.height(72.dp) else Modifier.aspectRatio(1.7f))
+            .then(if (fullWidth) Modifier.height(72.dp) else Modifier.aspectRatio(1.6f))
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(16.dp),
-        color = container,
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
     ) {
         if (fullWidth) {
-            // Undetermined is task-only: the total already reflects tasks, so no type split here.
             Row(
                 modifier = Modifier.padding(horizontal = 20.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                FilterDisc(iconRes, discContainer, discContent)
+                Spacer(Modifier.size(16.dp))
                 Text(
                     text = count.total.toString(),
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = content,
+                    style = NotiType.statNumber,
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(Modifier.size(16.dp))
-                Text(text = label, style = MaterialTheme.typography.titleMedium, color = content)
+                Text(text = label, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
             }
         } else {
             Column(
@@ -343,17 +363,38 @@ private fun SmartFilterBox(
                     .padding(16.dp),
                 verticalArrangement = Arrangement.SpaceBetween,
             ) {
-                Text(
-                    text = count.total.toString(),
-                    style = MaterialTheme.typography.headlineLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = content,
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    FilterDisc(iconRes, discContainer, discContent)
+                    Text(
+                        text = count.total.toString(),
+                        style = NotiType.statNumber,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
                 Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                    Text(text = label, style = MaterialTheme.typography.titleSmall, color = content)
-                    TypeBreakdown(count = count, content = content)
+                    Text(text = label, style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onSurface)
+                    TypeBreakdown(count = count, content = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
+        }
+    }
+}
+
+/** Small colored icon disc — the sanctioned spot of section color on an otherwise neutral tile. */
+@Composable
+private fun FilterDisc(iconRes: Int, container: Color, content: Color) {
+    Surface(shape = CircleShape, color = container, modifier = Modifier.size(34.dp)) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                painter = painterResource(iconRes),
+                contentDescription = null,
+                tint = content,
+                modifier = Modifier.size(18.dp),
+            )
         }
     }
 }
@@ -386,8 +427,7 @@ private fun TypeCountChip(value: Int, iconRes: Int, content: Color) {
     ) {
         Text(
             text = value.toString(),
-            style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.SemiBold,
+            style = NotiType.metadata,
             color = content,
         )
         Icon(
@@ -401,11 +441,10 @@ private fun TypeCountChip(value: Int, iconRes: Int, content: Color) {
 
 @Composable
 private fun CountBadge(count: Int, contentColor: Color, containerColor: Color) {
-    Surface(shape = RoundedCornerShape(12.dp), color = containerColor) {
+    Surface(shape = MaterialTheme.shapes.extraSmall, color = containerColor) {
         Text(
             text = count.toString(),
             style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.SemiBold,
             color = contentColor,
             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
         )

--- a/app/src/main/java/org/muilab/notigpt/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/home/HomeScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -62,6 +63,8 @@ fun HomeScreen(
     onOpenReview: () -> Unit,
     onOpenNotiCategory: (String) -> Unit,
     onOpenSavedList: (SavedListFilter) -> Unit,
+    dueReminderCount: Int = 0,
+    onOpenReminders: () -> Unit = {},
     homeViewModel: HomeViewModel = viewModel(),
 ) {
     val reviewCounts by homeViewModel.reviewCounts.collectAsState()
@@ -81,6 +84,11 @@ fun HomeScreen(
     ) {
         item {
             ReviewRow(counts = reviewCounts, onClick = onOpenReview)
+        }
+
+        // Slim, zero-cost-when-empty strip: due scheduled reminders the user hasn't seen yet.
+        if (dueReminderCount > 0) {
+            item { RemindersDueStrip(count = dueReminderCount, onClick = onOpenReminders) }
         }
 
         item { HomeSectionHeader(stringResource(R.string.home_section_notifications)) }
@@ -168,6 +176,46 @@ private fun ReviewRow(counts: ReviewCounts, onClick: () -> Unit) {
             if (counts.total > 0) {
                 CountBadge(counts.total, MaterialTheme.colorScheme.onPrimaryContainer, MaterialTheme.colorScheme.primaryContainer)
             }
+        }
+    }
+}
+
+/** Slim due-reminders strip (accent = due-soon). Opens the scheduled Reminders screen. */
+@Composable
+private fun RemindersDueStrip(count: Int, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Dimens.screenH, vertical = 4.dp)
+            .clickable(onClick = onClick),
+        shape = MaterialTheme.shapes.medium,
+        color = NotiTheme.semantic.dueSoonContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = Dimens.cardInner, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.notifications_active),
+                contentDescription = null,
+                tint = NotiTheme.semantic.onDueSoonContainer,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.size(12.dp))
+            Text(
+                text = stringResource(R.string.home_reminders_due, count),
+                style = MaterialTheme.typography.titleSmall,
+                color = NotiTheme.semantic.onDueSoonContainer,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                painter = painterResource(R.drawable.keyboard_arrow_down),
+                contentDescription = null,
+                tint = NotiTheme.semantic.onDueSoonContainer,
+                modifier = Modifier
+                    .size(20.dp)
+                    .rotate(-90f),
+            )
         }
     }
 }

--- a/app/src/main/java/org/muilab/notigpt/ui/notification/component/action/NotiActionIconButton.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/notification/component/action/NotiActionIconButton.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 
 /**
- * Icon button for one Android notification action.
+ * Circular icon button for one notification action (swipe-reveal strip, pin overlay).
  *
  * Keep this component focused on rendering and click dispatch. Action execution belongs to the drawer
  * ViewModel/service path because it may interact with Android PendingIntents.
@@ -29,21 +29,18 @@ fun NotiActionIconButton(
     onClick: () -> Unit,
     color: Color = Color.Unspecified
 ) {
-    val buttonBgColor = MaterialTheme.colorScheme.surfaceContainerHighest // 讓按鈕最亮，看起來可點擊
-
     Box(
         modifier = Modifier
-            .size(48.dp) // 稍微加大一點點，方便手指點擊
-            .clip(RoundedCornerShape(12.dp)) // 圓角跟卡片呼應
-            .background(buttonBgColor) // 使用更亮的背景
+            .size(44.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
         Icon(
             painter = painterResource(id = iconRes),
             contentDescription = contentDescription,
-            modifier = Modifier.size(24.dp),
-            // 圖示顏色使用對應的 On 背景色
+            modifier = Modifier.size(22.dp),
             tint = if (color == Color.Unspecified) MaterialTheme.colorScheme.onSurfaceVariant else color
         )
     }

--- a/app/src/main/java/org/muilab/notigpt/ui/notification/component/action/NotiFeedbackDropdown.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/notification/component/action/NotiFeedbackDropdown.kt
@@ -1,7 +1,6 @@
 package org.muilab.notigpt.ui.notification.component.action
 
 import android.content.Context
-import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.muilab.notigpt.model.notifications.NotiUnit
+import org.muilab.notigpt.ui.common.feedback.AppSnackbar
 
 /**
  * Dropdown for user feedback on notification extraction/classification.
@@ -39,7 +39,7 @@ fun NotiFeedbackDropdown(context: Context, notiUnit: NotiUnit, isDropdownMenuExp
         Column {
             Row {
                 Button(onClick = {
-                    Toast.makeText(context, "Start Updating Notification", Toast.LENGTH_SHORT).show()
+                    AppSnackbar.show("Start Updating Notification")
 //                    enqueueUpdateNotification(context, notiUnit.notiKey)
                     isDropdownMenuExpanded.value = false
                 }) {

--- a/app/src/main/java/org/muilab/notigpt/ui/notification/component/card/noticard/NotiCard.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/notification/component/card/noticard/NotiCard.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.border
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.AnchoredDraggableState
-import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -38,15 +38,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import kotlinx.coroutines.launch
+import org.muilab.notigpt.R
 import org.muilab.notigpt.model.notifications.NotiDisplayUnit
 import org.muilab.notigpt.model.notifications.NotiRecord
 import org.muilab.notigpt.ui.notification.component.card.noticard.elements.NOTI_CARD_COLLAPSE_THRESHOLD_PX_DEFAULT
@@ -113,9 +116,11 @@ fun NotiCard(
 
     val backgroundColor = MaterialTheme.colorScheme.surfaceBright
 
-    val borderColor = MaterialTheme.colorScheme.outline
-
-    val borderWidth = if (notiUnit.sortPosition != -1) 3.dp else 1.dp
+    // A single hairline; a pinned/sorted card is marked by a primary-tinted 1.5dp edge instead of a
+    // heavy outline. (Previously an outline border plus a second rim border stacked on the card.)
+    val isHighlighted = notiUnit.sortPosition != -1
+    val borderColor = if (isHighlighted) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
+    val borderWidth = if (isHighlighted) 1.5.dp else 1.dp
 
     // Expand state
     val maxHeightDp = 200.dp
@@ -186,6 +191,7 @@ fun NotiCard(
     }
 
     val coroutineScope = rememberCoroutineScope()
+    val haptic = androidx.compose.ui.platform.LocalHapticFeedback.current
     val horizontalOffsetX = remember { Animatable(0f) }
     var endActionsWidth by remember { mutableFloatStateOf(0f) }
     var cardWidth by remember { mutableFloatStateOf(0f) }
@@ -201,22 +207,59 @@ fun NotiCard(
         swipeDeleteLeft = swipeDeleteLeft,
         excludedBounds = excludedBoundsRelativeToSurface,
         horizontalOffsetX = horizontalOffsetX,
-        onDismiss = { drawerViewModel.archiveNewNotificationCard(notiKey) },
+        onDismiss = {
+            org.muilab.notigpt.ui.common.feedback.Haptics.commit(haptic)
+            drawerViewModel.archiveNewNotificationCard(notiKey)
+        },
         scope = coroutineScope,
         onSwipeActiveChanged = { isSwipeActive = it },
     )
 
     val scaleValue by animateFloatAsState(if (isDragging) 1.02f else 1f)
-    val isDarkTheme = isSystemInDarkTheme()
 
-    val rimColor = if (isDarkTheme) Color.White.copy(alpha = 0.08f) else Color.Black.copy(alpha = 0.06f)
-    val surfaceBorderModifier = Modifier.border(1.dp, rimColor, shape = MaterialTheme.shapes.large)
     val targetLift = 0.dp
     val lift by animateDpAsState(targetLift, label = "lift")
 
+    // TalkBack custom actions mirror every gesture affordance (swipe/drag/long-press) so the card is
+    // fully operable without them. Labels resolved here since the semantics block is not composable.
+    val a11yArchive = stringResource(R.string.a11y_archive)
+    val a11yPin = stringResource(R.string.ui_noti_action_pin)
+    val a11yUnpin = stringResource(R.string.ui_noti_action_unpin)
+    val a11yExpand = stringResource(R.string.a11y_expand)
+    val a11yCollapse = stringResource(R.string.a11y_collapse)
+    val a11yExtract = stringResource(R.string.ui_action_extract_reminder)
+    val a11yCreateReminder = stringResource(R.string.ui_reminders_create_button)
+    val cardActions = buildList {
+        add(androidx.compose.ui.semantics.CustomAccessibilityAction(a11yArchive) {
+            org.muilab.notigpt.ui.common.feedback.Haptics.commit(haptic)
+            drawerViewModel.archiveNewNotificationCard(notiKey); true
+        })
+        add(androidx.compose.ui.semantics.CustomAccessibilityAction(if (isPinned) a11yUnpin else a11yPin) {
+            drawerViewModel.actOnNoti(notiKey, if (isPinned) "unpin" else "pin"); true
+        })
+        if (requiresExpansion) add(
+            androidx.compose.ui.semantics.CustomAccessibilityAction(
+                if (anchored.offset < collapseThreshold) a11yExpand else a11yCollapse
+            ) {
+                coroutineScope.launch {
+                    if (anchored.offset < 20f) anchored.animateTo(NotiExpandState.Opened)
+                    else anchored.animateTo(NotiExpandState.Collapsed)
+                }; true
+            }
+        )
+        add(androidx.compose.ui.semantics.CustomAccessibilityAction(a11yExtract) {
+            drawerViewModel.actOnNoti(notiKey, "extract_reminder"); true
+        })
+        onCreateReminder?.let { cb ->
+            add(androidx.compose.ui.semantics.CustomAccessibilityAction(a11yCreateReminder) {
+                cb(notiOverallTitle, notiRecords); true
+            })
+        }
+    }
+
     Box(
         modifier = Modifier
-            .padding(vertical = 1.dp, horizontal = 20.dp)
+            .padding(vertical = 3.dp, horizontal = org.muilab.notigpt.ui.theme.Dimens.screenH)
             .graphicsLayer {
                 scaleX = scaleValue
                 scaleY = scaleValue
@@ -271,7 +314,10 @@ fun NotiCard(
                         drawerViewModel.accessAndDismissNotification(notiUnit)
                     },
                     onLongClick = {
-                        if (!isSortingMode) showOptionsDialog = true
+                        if (!isSortingMode) {
+                            org.muilab.notigpt.ui.common.feedback.Haptics.longPress(haptic)
+                            showOptionsDialog = true
+                        }
                     },
                 )
                 // Swipe handler lives at the Surface level so the whole card is swipeable (except the
@@ -279,7 +325,7 @@ fun NotiCard(
                 // then in the same coordinate space as surfaceBoundsInWindow.
                 .then(if (isSortingMode) Modifier else swipeModifier)
                 .onGloballyPositioned { coords -> surfaceBoundsInWindow = coords.boundsInWindow() }
-                .then(surfaceBorderModifier),
+                .semantics { customActions = cardActions },
             shape = MaterialTheme.shapes.large,
             shadowElevation = 0.dp,
             color = backgroundColor,

--- a/app/src/main/java/org/muilab/notigpt/ui/notification/component/card/noticard/elements/NotiCardOptionsDialog.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/notification/component/card/noticard/elements/NotiCardOptionsDialog.kt
@@ -2,19 +2,19 @@ package org.muilab.notigpt.ui.notification.component.card.noticard.elements
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -23,15 +23,16 @@ import org.muilab.notigpt.R
 import org.muilab.notigpt.ui.notification.viewmodel.DrawerViewModel
 
 /**
- * Options dialog and transient dialog state for one notification card.
- *
- * Keep dialog-local visibility and text input here. Persisted actions such as pinning, extraction, or feedback
- * should continue flowing through callbacks owned by the screen/ViewModel.
+ * Options for one notification card, shown as a Material bottom sheet of list items (was an
+ * AlertDialog of text buttons). Long-press on the card opens it. Every action the card exposes
+ * elsewhere is reachable here: pin/unpin, extract task, and — when available — create a scheduled
+ * reminder. Persisted actions flow through callbacks owned by the screen/ViewModel.
  */
 data class NotiCardOptionsState(
     val isPinned: Boolean,
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @RequiresApi(Build.VERSION_CODES.S)
 @Composable
 fun NotiCardOptionsDialog(
@@ -44,106 +45,52 @@ fun NotiCardOptionsDialog(
 ) {
     if (!show) return
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.ui_noti_options_title)) },
-        text = {
-            Column {
-                TextButton(
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(Modifier.navigationBarsPadding()) {
+            OptionRow(
+                iconRes = if (state.isPinned) R.drawable.pin_yes else R.drawable.pin_no,
+                label = stringResource(if (state.isPinned) R.string.ui_noti_action_unpin else R.string.ui_noti_action_pin),
+                onClick = {
+                    drawerViewModel.actOnNoti(notiKey, if (state.isPinned) "unpin" else "pin")
+                    onDismiss()
+                },
+            )
+            OptionRow(
+                iconRes = R.drawable.task,
+                label = stringResource(R.string.ui_action_extract_reminder),
+                onClick = {
+                    drawerViewModel.actOnNoti(notiKey, "extract_reminder")
+                    onDismiss()
+                },
+            )
+            if (onCreateReminder != null) {
+                OptionRow(
+                    iconRes = R.drawable.schedule,
+                    label = stringResource(R.string.ui_reminders_create_button),
                     onClick = {
-                        drawerViewModel.actOnNoti(
-                            notiKey,
-                            if (state.isPinned) "unpin" else "pin",
-                        )
+                        onCreateReminder()
                         onDismiss()
                     },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Start,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Icon(
-                            painter = painterResource(if (state.isPinned) R.drawable.pin_yes else R.drawable.pin_no),
-                            contentDescription = stringResource(if (state.isPinned) R.string.ui_noti_action_unpin else R.string.ui_noti_action_pin),
-                            modifier = Modifier.size(24.dp),
-                        )
-                        Spacer(Modifier.width(12.dp))
-                        Text(stringResource(if (state.isPinned) R.string.ui_noti_action_unpin else R.string.ui_noti_action_pin))
-                    }
-                }
-//                TextButton(
-//                    onClick = {
-//                        drawerViewModel.actOnNoti(notiKey, "dismiss")
-//                        onDismiss()
-//                    },
-//                    modifier = Modifier.fillMaxWidth(),
-//                ) {
-//                    Row(
-//                        verticalAlignment = Alignment.CenterVertically,
-//                        horizontalArrangement = Arrangement.Start,
-//                        modifier = Modifier.fillMaxWidth(),
-//                    ) {
-//                        Icon(
-//                            painter = painterResource(R.drawable.close),
-//                            contentDescription = stringResource(R.string.ui_noti_action_dismiss),
-//                            modifier = Modifier.size(24.dp),
-//                        )
-//                        Spacer(Modifier.width(12.dp))
-//                        Text(stringResource(R.string.ui_noti_action_dismiss))
-//                    }
-//                }
-
-                TextButton(
-                    onClick = {
-                        drawerViewModel.actOnNoti(notiKey, "extract_reminder")
-                        onDismiss()
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Start,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.task),
-                            contentDescription = stringResource(R.string.ui_action_extract_reminder),
-                            modifier = Modifier.size(24.dp),
-                        )
-                        Spacer(Modifier.width(12.dp))
-                        Text(stringResource(R.string.ui_action_extract_reminder))
-                    }
-                }
-
-                if (onCreateReminder != null) {
-                    TextButton(
-                        onClick = {
-                            onCreateReminder()
-                            onDismiss()
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Start,
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.schedule),
-                                contentDescription = stringResource(R.string.ui_reminders_create_button),
-                                modifier = Modifier.size(24.dp),
-                            )
-                            Spacer(Modifier.width(12.dp))
-                            Text(stringResource(R.string.ui_reminders_create_button))
-                        }
-                    }
-                }
+                )
             }
+        }
+    }
+}
+
+@Composable
+private fun OptionRow(iconRes: Int, label: String, onClick: () -> Unit) {
+    ListItem(
+        headlineContent = { Text(label) },
+        leadingContent = {
+            Icon(
+                painter = painterResource(iconRes),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
         },
-        confirmButton = {
-            TextButton(onClick = onDismiss) { Text(stringResource(R.string.ui_action_close)) }
-        },
+        colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.clickable(onClick = onClick),
     )
 }

--- a/app/src/main/java/org/muilab/notigpt/ui/notification/component/card/noticard/elements/NotiCardOverlayButtons.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/notification/component/card/noticard/elements/NotiCardOverlayButtons.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -137,7 +138,7 @@ fun NotiCardOverlayButtons(
                         if (isPinned) drawerViewModel.actOnNoti(notiKey, NotiActionType.Unpin)
                         else drawerViewModel.actOnNoti(notiKey, NotiActionType.Pin)
                     },
-                    if (isPinned) Color(76, 139, 245) else Color.Unspecified,
+                    if (isPinned) MaterialTheme.colorScheme.primary else Color.Unspecified,
                 )
             }
         }

--- a/app/src/main/java/org/muilab/notigpt/ui/notification/screen/NotificationHistoryScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/notification/screen/NotificationHistoryScreen.kt
@@ -14,19 +14,22 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -267,6 +270,7 @@ private fun HistoryRecordContent(record: NotiRecord, onLongPress: (HistoryMenuTa
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun HistoryActionMenu(
     drawerViewModel: DrawerViewModel,
@@ -276,48 +280,34 @@ private fun HistoryActionMenu(
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
     val scope = rememberCoroutineScope()
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.ui_noti_menu_title)) },
-        text = {
-            Column {
-                TextButton(
-                    onClick = {
-                        clipboard.setText(AnnotatedString(target.copyText))
-                        AppSnackbar.show(context.getString(R.string.history_copied))
-                        onDismiss()
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                        Icon(painterResource(R.drawable.copy), contentDescription = null, modifier = Modifier.size(22.dp))
-                        Spacer(Modifier.width(12.dp))
-                        Text(stringResource(R.string.history_action_copy))
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(Modifier.navigationBarsPadding()) {
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.history_action_copy)) },
+                leadingContent = { Icon(painterResource(R.drawable.copy), contentDescription = null, modifier = Modifier.size(24.dp)) },
+                colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.surface),
+                modifier = Modifier.clickable {
+                    clipboard.setText(AnnotatedString(target.copyText))
+                    AppSnackbar.show(context.getString(R.string.history_copied))
+                    onDismiss()
+                },
+            )
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.ui_action_extract_reminder)) },
+                leadingContent = { Icon(painterResource(R.drawable.task), contentDescription = null, modifier = Modifier.size(24.dp)) },
+                colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.surface),
+                modifier = Modifier.clickable {
+                    scope.launch {
+                        val idsJson = com.google.gson.Gson().toJson(target.recordIds.distinct())
+                        drawerViewModel.actOnNoti(target.notiKey, "extract_reminder_with_records::$idsJson")
+                        AppSnackbar.show(context.getString(R.string.history_extract_requested))
                     }
-                }
-                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                TextButton(
-                    onClick = {
-                        scope.launch {
-                            val idsJson = com.google.gson.Gson().toJson(target.recordIds.distinct())
-                            drawerViewModel.actOnNoti(target.notiKey, "extract_reminder_with_records::$idsJson")
-                            AppSnackbar.show(context.getString(R.string.history_extract_requested))
-                        }
-                        onDismiss()
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                        Icon(painterResource(R.drawable.task), contentDescription = null, modifier = Modifier.size(22.dp))
-                        Spacer(Modifier.width(12.dp))
-                        Text(stringResource(R.string.ui_action_extract_reminder))
-                    }
-                }
-            }
-        },
-        confirmButton = {},
-        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.ui_action_cancel)) } },
-    )
+                    onDismiss()
+                },
+            )
+        }
+    }
 }
 
 private fun NotiRecord.toMenuTarget(): HistoryMenuTarget =

--- a/app/src/main/java/org/muilab/notigpt/ui/notification/screen/NotificationHistoryScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/notification/screen/NotificationHistoryScreen.kt
@@ -1,6 +1,6 @@
 package org.muilab.notigpt.ui.notification.screen
 
-import android.widget.Toast
+import org.muilab.notigpt.ui.common.feedback.AppSnackbar
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -284,7 +284,7 @@ private fun HistoryActionMenu(
                 TextButton(
                     onClick = {
                         clipboard.setText(AnnotatedString(target.copyText))
-                        Toast.makeText(context, R.string.history_copied, Toast.LENGTH_SHORT).show()
+                        AppSnackbar.show(context.getString(R.string.history_copied))
                         onDismiss()
                     },
                     modifier = Modifier.fillMaxWidth(),
@@ -301,7 +301,7 @@ private fun HistoryActionMenu(
                         scope.launch {
                             val idsJson = com.google.gson.Gson().toJson(target.recordIds.distinct())
                             drawerViewModel.actOnNoti(target.notiKey, "extract_reminder_with_records::$idsJson")
-                            Toast.makeText(context, R.string.history_extract_requested, Toast.LENGTH_SHORT).show()
+                            AppSnackbar.show(context.getString(R.string.history_extract_requested))
                         }
                         onDismiss()
                     },

--- a/app/src/main/java/org/muilab/notigpt/ui/notification/screen/NotificationHistoryScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/notification/screen/NotificationHistoryScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -179,7 +178,7 @@ private fun HistoryGroupCard(
                     )
                 },
             ),
-        shape = RoundedCornerShape(12.dp),
+        shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
         border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
@@ -229,7 +228,7 @@ private fun HistoryRecordCard(
                 onClick = {},
                 onLongClick = { onLongPress(record.toMenuTarget()) },
             ),
-        shape = RoundedCornerShape(12.dp),
+        shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
         border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {

--- a/app/src/main/java/org/muilab/notigpt/ui/notification/viewmodel/DrawerViewModelFactory.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/notification/viewmodel/DrawerViewModelFactory.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import org.muilab.notigpt.data.repository.notification.NotiRepository
 import org.muilab.notigpt.ui.common.clipboard.AndroidClipboardController
 import org.muilab.notigpt.data.export.MediaStoreNotiLogExporter
-import org.muilab.notigpt.ui.common.feedback.ToastUserToaster
+import org.muilab.notigpt.ui.common.feedback.SnackbarUserToaster
 
 /**
  * Factory for constructing DrawerViewModel with Android context-backed repositories.
@@ -26,7 +26,7 @@ class DrawerViewModelFactory(
                 application = application,
                 notiRepository = notiRepository,
                 clipboard = AndroidClipboardController(appContext),
-                notifier = ToastUserToaster(appContext),
+                notifier = SnackbarUserToaster(),
                 logExporter = MediaStoreNotiLogExporter(appContext),
             ) as T
         }

--- a/app/src/main/java/org/muilab/notigpt/ui/preference/viewmodel/PreferenceViewModel.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/preference/viewmodel/PreferenceViewModel.kt
@@ -2,7 +2,7 @@ package org.muilab.notigpt.ui.preference.viewmodel
 
 import android.app.Application
 import android.util.Log
-import android.widget.Toast
+import org.muilab.notigpt.ui.common.feedback.AppSnackbar
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
@@ -369,20 +369,14 @@ class PreferenceViewModel(application: Application) : AndroidViewModel(applicati
 
                     val toast = result.toastMessage
                     if (!toast.isNullOrBlank()) {
-                        withContext(Dispatchers.Main) {
-                            Toast.makeText(getApplication(), toast, Toast.LENGTH_LONG).show()
-                        }
+                        AppSnackbar.show(toast)
                     }
                 } else {
-                    withContext(Dispatchers.Main) {
-                        Toast.makeText(getApplication(), R.string.pref_sync_failed, Toast.LENGTH_SHORT).show()
-                    }
+                    AppSnackbar.show(getApplication<Application>().getString(R.string.pref_sync_failed))
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Quick-sync error", e)
-                withContext(Dispatchers.Main) {
-                    Toast.makeText(getApplication(), R.string.pref_sync_error, Toast.LENGTH_SHORT).show()
-                }
+                AppSnackbar.show(getApplication<Application>().getString(R.string.pref_sync_error))
             } finally {
                 withContext(Dispatchers.Main) {
                     _bottomSheetStep.value = BottomSheetStep.Hidden

--- a/app/src/main/java/org/muilab/notigpt/ui/reminder/screen/RemindersScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/reminder/screen/RemindersScreen.kt
@@ -106,6 +106,7 @@ import org.muilab.notigpt.model.features.SavedSubItem
 import org.muilab.notigpt.data.export.asExportable
 import org.muilab.notigpt.ui.preference.component.PreferenceLearningBottomSheet
 import org.muilab.notigpt.ui.common.component.DueChip
+import org.muilab.notigpt.ui.common.feedback.AppSnackbar
 import org.muilab.notigpt.ui.reminder.component.ExportChooserDialog
 import org.muilab.notigpt.ui.theme.NotiTheme
 import org.muilab.notigpt.ui.notification.component.RelatedNotificationPreview
@@ -237,19 +238,11 @@ fun RemindersScreen(
     LaunchedEffect(googleTasksExportResult) {
         when (val r = googleTasksExportResult) {
             is ReminderViewModel.GoogleTasksExportResult.Success -> {
-                android.widget.Toast.makeText(
-                    context,
-                    strGoogleTasksSuccess,
-                    android.widget.Toast.LENGTH_SHORT
-                ).show()
+                AppSnackbar.show(strGoogleTasksSuccess)
                 vm.clearGoogleTasksExportResult()
             }
             is ReminderViewModel.GoogleTasksExportResult.Error -> {
-                android.widget.Toast.makeText(
-                    context,
-                    strGoogleTasksErrorFmt.replace("%s", r.message ?: ""),
-                    android.widget.Toast.LENGTH_LONG
-                ).show()
+                AppSnackbar.show(strGoogleTasksErrorFmt.replace("%s", r.message ?: ""))
                 vm.clearGoogleTasksExportResult()
             }
             is ReminderViewModel.GoogleTasksExportResult.NotSignedIn -> {
@@ -769,11 +762,7 @@ fun RemindersScreen(
                 try {
                     context.startActivity(calIntent)
                 } catch (_: Exception) {
-                    android.widget.Toast.makeText(
-                        context,
-                        strGoogleCalendarNoApp,
-                        android.widget.Toast.LENGTH_SHORT
-                    ).show()
+                    AppSnackbar.show(strGoogleCalendarNoApp)
                 }
             },
         )

--- a/app/src/main/java/org/muilab/notigpt/ui/reminder/screen/RemindersScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/reminder/screen/RemindersScreen.kt
@@ -109,6 +109,8 @@ import org.muilab.notigpt.ui.common.component.DueChip
 import org.muilab.notigpt.ui.common.feedback.AppSnackbar
 import org.muilab.notigpt.ui.reminder.component.ExportChooserDialog
 import org.muilab.notigpt.ui.theme.NotiTheme
+import org.muilab.notigpt.ui.theme.NotiType
+import org.muilab.notigpt.ui.theme.Dimens
 import org.muilab.notigpt.ui.notification.component.RelatedNotificationPreview
 import org.muilab.notigpt.ui.reminder.component.SavedSubItemRow
 import org.muilab.notigpt.ui.reminder.component.SavedSubItemListInCard
@@ -124,7 +126,6 @@ import java.util.Calendar
 import org.muilab.notigpt.ui.common.clipboard.AndroidClipboardController
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.snapshotFlow
@@ -943,8 +944,8 @@ fun ReminderCard(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 6.dp),
-        shape = RoundedCornerShape(12.dp),
+            .padding(horizontal = Dimens.screenH, vertical = Dimens.cardOuterV),
+        shape = MaterialTheme.shapes.medium,
         color = if (selectionMode && selected) MaterialTheme.colorScheme.surfaceContainerHigh else MaterialTheme.colorScheme.surfaceContainerLow,
         border = BorderStroke(
             if (selectionMode && selected) 1.5.dp else 0.5.dp,
@@ -1012,7 +1013,7 @@ fun ReminderCard(
                 // Review badge: stays until the user explicitly acknowledges in the detail view.
                 if (reminder.isNewLike && !selectionMode) {
                     Surface(
-                        shape = RoundedCornerShape(6.dp),
+                        shape = MaterialTheme.shapes.extraSmall,
                         color = MaterialTheme.colorScheme.secondaryContainer,
                         modifier = Modifier.padding(bottom = 2.dp),
                     ) {
@@ -1030,15 +1031,17 @@ fun ReminderCard(
 
                 // Title row
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    val titleStyle = if (reminder.isTask && reminder.isCompleted) {
-                        MaterialTheme.typography.titleMedium.copy(textDecoration = TextDecoration.LineThrough)
-                    } else MaterialTheme.typography.titleMedium
+                    val completed = reminder.isTask && reminder.isCompleted
+                    val titleStyle = if (completed) {
+                        NotiType.cardTitle.copy(textDecoration = TextDecoration.LineThrough)
+                    } else NotiType.cardTitle
 
                     Text(
                         text = reminder.title.ifBlank {
                             if (reminder.isTask) stringResource(R.string.ui_reminders_untitled_task) else stringResource(R.string.ui_reminders_untitled_memo)
                         },
                         style = titleStyle,
+                        color = if (completed) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface,
                         maxLines = if (expanded) Int.MAX_VALUE else 2,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f)
@@ -1284,7 +1287,7 @@ private fun DoDateBottomButton(
     val tint = if (hasDo) accent else MaterialTheme.colorScheme.onSurfaceVariant
     Row(
         modifier = Modifier
-            .clip(RoundedCornerShape(8.dp))
+            .clip(MaterialTheme.shapes.small)
             .clickable(onClick = onClick)
             .padding(horizontal = 8.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/org/muilab/notigpt/ui/reminder/screen/ScheduledRemindersScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/reminder/screen/ScheduledRemindersScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -115,7 +114,7 @@ private fun ScheduledReminderCard(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(enabled = isDue) { onSeen() },
-        shape = RoundedCornerShape(12.dp),
+        shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
         border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {

--- a/app/src/main/java/org/muilab/notigpt/ui/reminder/screen/ScheduledRemindersScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/reminder/screen/ScheduledRemindersScreen.kt
@@ -191,7 +191,7 @@ fun ReminderDateTimeDialog(
         title = { Text(title) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Reminder time: ${getAbsoluteTimeStr(selectedAtMs)}")
+                Text(stringResource(R.string.scheduled_reminder_time, getAbsoluteTimeStr(selectedAtMs)))
                 Button(onClick = {
                     val pickerCal = Calendar.getInstance().apply { timeInMillis = selectedAtMs }
                     TimePickerDialog(
@@ -207,10 +207,10 @@ fun ReminderDateTimeDialog(
                         pickerCal.get(Calendar.MINUTE),
                         true,
                     ).show()
-                }) { Text("Pick time") }
+                }) { Text(stringResource(R.string.scheduled_pick_time)) }
             }
         },
-        confirmButton = { TextButton(onClick = { onConfirm(selectedAtMs) }) { Text("Save") } },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        confirmButton = { TextButton(onClick = { onConfirm(selectedAtMs) }) { Text(stringResource(R.string.ui_action_save)) } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.ui_action_cancel)) } },
     )
 }

--- a/app/src/main/java/org/muilab/notigpt/ui/review/ReviewScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/review/ReviewScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.FilterChip
@@ -128,6 +127,7 @@ fun ReviewScreen(
                     val top = filtered.firstOrNull()
                     FilledIconButton(
                         onClick = { top?.let(reviewViewModel::reject) },
+                        modifier = Modifier.size(56.dp),
                         colors = IconButtonDefaults.filledIconButtonColors(
                             containerColor = MaterialTheme.colorScheme.errorContainer,
                             contentColor = MaterialTheme.colorScheme.onErrorContainer,
@@ -143,6 +143,7 @@ fun ReviewScreen(
                     }
                     FilledIconButton(
                         onClick = { top?.let(reviewViewModel::approve) },
+                        modifier = Modifier.size(56.dp),
                         colors = IconButtonDefaults.filledIconButtonColors(
                             containerColor = NotiTheme.semantic.keepContainer,
                             contentColor = NotiTheme.semantic.onKeepContainer,
@@ -236,10 +237,9 @@ private fun MinimalReviewCard(
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
-        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-        shadowElevation = 4.dp,
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLowest,
+        shadowElevation = 6.dp,
     ) {
         Box {
             Column(Modifier.padding(20.dp)) {
@@ -302,7 +302,7 @@ private fun androidx.compose.foundation.layout.BoxScope.SwipeGlyph(
             .align(alignment)
             .padding(16.dp)
             .graphicsLayer { this.alpha = alpha },
-        shape = RoundedCornerShape(8.dp),
+        shape = MaterialTheme.shapes.small,
         color = color.copy(alpha = 0.16f),
         border = androidx.compose.foundation.BorderStroke(2.dp, color),
     ) {

--- a/app/src/main/java/org/muilab/notigpt/ui/review/component/ReviewCardStack.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/review/component/ReviewCardStack.kt
@@ -1,10 +1,10 @@
 package org.muilab.notigpt.ui.review.component
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -17,11 +17,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.muilab.notigpt.model.features.SavedItem
+import org.muilab.notigpt.ui.common.feedback.Haptics
+import org.muilab.notigpt.ui.theme.MotionSpecs
 
 private const val MAX_VISIBLE = 3
 private const val MAX_ROTATION_DEG = 10f
@@ -29,7 +31,8 @@ private const val MAX_ROTATION_DEG = 10f
 /**
  * Tinder-style swipe stack. The top card drags horizontally; a commit past the threshold flies it
  * off-screen and fires [onApprove] (right) or [onReject] (left). Behind cards are scaled/offset to
- * suggest depth. Tapping the top card calls [onExpand].
+ * suggest depth. Tapping the top card calls [onExpand]. Width comes from the layout constraints
+ * (not a deprecated screen-metrics read).
  */
 @Composable
 fun ReviewCardStack(
@@ -40,11 +43,11 @@ fun ReviewCardStack(
     modifier: Modifier = Modifier,
     minimalCard: @Composable (item: SavedItem, approveProgress: Float, rejectProgress: Float) -> Unit,
 ) {
-    val density = LocalDensity.current
-    val screenWidthPx = with(density) { LocalConfiguration.current.screenWidthDp.dp.toPx() }
-    val commitThreshold = screenWidthPx * 0.30f
+    BoxWithConstraints(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        val density = LocalDensity.current
+        val stackWidthPx = with(density) { maxWidth.toPx() }
+        val commitThreshold = stackWidthPx * 0.30f
 
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         val visible = items.take(MAX_VISIBLE)
         // Draw deepest first so the top card renders last (in front).
         visible.reversed().forEachIndexed { indexFromBack, item ->
@@ -54,7 +57,7 @@ fun ReviewCardStack(
                     TopCard(
                         item = item,
                         commitThreshold = commitThreshold,
-                        screenWidthPx = screenWidthPx,
+                        screenWidthPx = stackWidthPx,
                         onApprove = onApprove,
                         onReject = onReject,
                         onExpand = onExpand,
@@ -91,6 +94,7 @@ private fun TopCard(
     minimalCard: @Composable (item: SavedItem, approveProgress: Float, rejectProgress: Float) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
+    val haptic = LocalHapticFeedback.current
     val offsetX = remember { Animatable(0f) }
 
     val approveProgress = (offsetX.value / commitThreshold).coerceIn(0f, 1f)
@@ -105,22 +109,36 @@ private fun TopCard(
                 rotationZ = (offsetX.value / screenWidthPx) * MAX_ROTATION_DEG
             }
             .pointerInput(item.savedItemId) {
+                // `acc` is the source of truth for both threshold ticks and the commit decision;
+                // offsetX mirrors it for rendering. `wasPast` ticks the haptic once per crossing.
+                var acc = 0f
+                var wasPast = false
                 detectDragGestures(
+                    onDragStart = {
+                        acc = offsetX.value
+                        wasPast = kotlin.math.abs(acc) > commitThreshold
+                    },
                     onDrag = { change, dragAmount ->
                         change.consume()
-                        scope.launch { offsetX.snapTo(offsetX.value + dragAmount.x) }
+                        acc += dragAmount.x
+                        scope.launch { offsetX.snapTo(acc) }
+                        val nowPast = kotlin.math.abs(acc) > commitThreshold
+                        if (nowPast && !wasPast) Haptics.thresholdCross(haptic)
+                        wasPast = nowPast
                     },
                     onDragEnd = {
                         when {
-                            offsetX.value > commitThreshold -> scope.launch {
-                                offsetX.animateTo(screenWidthPx * 1.5f, tween(250))
+                            acc > commitThreshold -> scope.launch {
+                                Haptics.commit(haptic)
+                                offsetX.animateTo(screenWidthPx * 1.5f, MotionSpecs.flyOff())
                                 onApprove(item)
                             }
-                            offsetX.value < -commitThreshold -> scope.launch {
-                                offsetX.animateTo(-screenWidthPx * 1.5f, tween(250))
+                            acc < -commitThreshold -> scope.launch {
+                                Haptics.commit(haptic)
+                                offsetX.animateTo(-screenWidthPx * 1.5f, MotionSpecs.flyOff())
                                 onReject(item)
                             }
-                            else -> scope.launch { offsetX.animateTo(0f, tween(200)) }
+                            else -> scope.launch { offsetX.animateTo(0f, MotionSpecs.settle()) }
                         }
                     },
                 )

--- a/app/src/main/java/org/muilab/notigpt/ui/review/component/ReviewDetailSheet.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/review/component/ReviewDetailSheet.kt
@@ -60,8 +60,7 @@ fun ReviewDetailSheet(
     ) {
         Text(
             text = item.title.ifBlank { stringResource(R.string.ui_reminders_untitled_task) },
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.SemiBold),
         )
 
         if (item.content.isNotBlank()) {

--- a/app/src/main/java/org/muilab/notigpt/ui/settings/SettingScreen.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/settings/SettingScreen.kt
@@ -5,8 +5,8 @@ import android.app.Application
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,11 +19,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -43,13 +47,15 @@ import org.muilab.notigpt.R
 import org.muilab.notigpt.data.repository.notification.NotiRepositoryProvider
 import org.muilab.notigpt.ui.notification.viewmodel.DrawerViewModel
 import org.muilab.notigpt.ui.notification.viewmodel.DrawerViewModelFactory
+import org.muilab.notigpt.ui.theme.Dimens
 import org.muilab.notigpt.util.SharedPreferencesManager
 
 /**
  * Settings route for runtime configuration, account integrations, and developer controls.
  *
- * Keep settings grouped by user-visible concern. Side effects should call platform/repository helpers rather than
- * being embedded as long-running work in composables.
+ * Grouped into iOS-style section cards (neutral surface, hairline dividers) rendered with Material
+ * [ListItem]s. Side effects call platform/repository helpers rather than embedding long-running work
+ * in composables.
  */
 @RequiresApi(Build.VERSION_CODES.S)
 @Composable
@@ -64,212 +70,183 @@ fun SettingsScreen() {
         )
     )
 
+    var useDynamicColor by remember { mutableStateOf(SharedPreferencesManager.useDynamicColor) }
+    var isLeftSwipe by remember { mutableStateOf(SharedPreferencesManager.swipeDeleteLeft) }
+    var extractionLanguage by remember { mutableStateOf(SharedPreferencesManager.targetExtractionLanguage) }
+    var showLanguagePicker by remember { mutableStateOf(false) }
+    var showExportDialog by remember { mutableStateOf(false) }
+    val originalLabel = stringResource(R.string.ui_settings_extraction_language_original)
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
+            .padding(bottom = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        // --- Dynamic color (Material You) toggle ---
-        var useDynamicColor by remember { mutableStateOf(SharedPreferencesManager.useDynamicColor) }
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f).padding(end = 8.dp)) {
-                Text(
-                    stringResource(R.string.ui_settings_dynamic_color),
-                    style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    stringResource(R.string.ui_settings_dynamic_color_desc),
-                    style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
-                    color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Switch(
-                checked = useDynamicColor,
-                onCheckedChange = {
-                    useDynamicColor = it
-                    SharedPreferencesManager.useDynamicColor = it
-                    // Re-run onCreate so NotiTheme re-reads the preference and re-applies the scheme.
-                    (context as? Activity)?.recreate()
+        // ── Appearance ──
+        SettingsSection(stringResource(R.string.settings_section_appearance)) {
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.ui_settings_dynamic_color)) },
+                supportingContent = { Text(stringResource(R.string.ui_settings_dynamic_color_desc)) },
+                trailingContent = {
+                    Switch(
+                        checked = useDynamicColor,
+                        onCheckedChange = {
+                            useDynamicColor = it
+                            SharedPreferencesManager.useDynamicColor = it
+                            // Re-run onCreate so NotiTheme re-reads the preference and re-applies the scheme.
+                            (context as? Activity)?.recreate()
+                        },
+                    )
                 },
+                colors = transparentListItem(),
             )
-        }
-
-        Spacer(modifier = Modifier.size(12.dp))
-
-        var isLeftSwipe by remember { mutableStateOf(SharedPreferencesManager.swipeDeleteLeft) }
-
-        // Simple radio row to choose swipe-delete direction
-        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), verticalAlignment = Alignment.CenterVertically) {
-            Text(stringResource(R.string.ui_settings_delete_on_swipe), modifier = Modifier.padding(end = 8.dp))
-
-            // Left Option
-            Row(modifier = Modifier.selectable(
-                selected = isLeftSwipe,
-                onClick = {
-                    isLeftSwipe = true
-                    SharedPreferencesManager.swipeDeleteLeft = true
-                },
-                role = Role.RadioButton
-            )) {
-                RadioButton(
-                    selected = isLeftSwipe,
-                    onClick = {
-                        isLeftSwipe = true
-                        SharedPreferencesManager.swipeDeleteLeft = true
+            RowDivider()
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.ui_settings_delete_on_swipe)) },
+                trailingContent = {
+                    androidx.compose.foundation.layout.Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        FilterChip(
+                            selected = isLeftSwipe,
+                            onClick = { isLeftSwipe = true; SharedPreferencesManager.swipeDeleteLeft = true },
+                            label = { Text(stringResource(R.string.ui_settings_left)) },
+                        )
+                        FilterChip(
+                            selected = !isLeftSwipe,
+                            onClick = { isLeftSwipe = false; SharedPreferencesManager.swipeDeleteLeft = false },
+                            label = { Text(stringResource(R.string.ui_settings_right)) },
+                        )
                     }
-                )
-                Text(stringResource(R.string.ui_settings_left), modifier = Modifier.padding(start = 4.dp, top = 12.dp))
-            }
-
-            Spacer(modifier = Modifier.size(16.dp))
-
-            // Right Option
-            Row(modifier = Modifier.selectable(
-                selected = !isLeftSwipe,
-                onClick = {
-                    isLeftSwipe = false
-                    SharedPreferencesManager.swipeDeleteLeft = false
                 },
-                role = Role.RadioButton
-            )) {
-                RadioButton(
-                    selected = !isLeftSwipe,
-                    onClick = {
-                        isLeftSwipe = false
-                        SharedPreferencesManager.swipeDeleteLeft = false
-                    }
-                )
-                Text(stringResource(R.string.ui_settings_right), modifier = Modifier.padding(start = 4.dp, top = 12.dp))
-            }
-        }
-
-        Spacer(modifier = Modifier.size(12.dp))
-
-
-        // --- Extraction language preference ---
-        var extractionLanguage by remember { mutableStateOf(SharedPreferencesManager.targetExtractionLanguage) }
-        var showLanguagePicker by remember { mutableStateOf(false) }
-        val originalLabel = stringResource(R.string.ui_settings_extraction_language_original)
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { showLanguagePicker = true }
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-        ) {
-            Text(
-                stringResource(R.string.ui_settings_extraction_language),
-                style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
-            )
-            Text(
-                extractionLanguageLabel(extractionLanguage, originalLabel),
-                style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
-                color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
+                colors = transparentListItem(),
             )
         }
 
-        if (showLanguagePicker) {
-            ExtractionLanguagePickerDialog(
-                selected = extractionLanguage,
-                originalLabel = originalLabel,
-                onSelect = { value ->
-                    extractionLanguage = value
-                    SharedPreferencesManager.targetExtractionLanguage = value
-                    showLanguagePicker = false
-                },
-                onDismiss = { showLanguagePicker = false },
+        // ── Extraction ──
+        SettingsSection(stringResource(R.string.settings_section_extraction)) {
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.ui_settings_extraction_language)) },
+                supportingContent = { Text(extractionLanguageLabel(extractionLanguage, originalLabel)) },
+                colors = transparentListItem(),
+                modifier = Modifier.clickable { showLanguagePicker = true },
             )
         }
 
-        Spacer(modifier = Modifier.size(24.dp))
+        // ── Data ──
+        SettingsSection(stringResource(R.string.settings_section_data)) {
+            ListItem(
+                headlineContent = { Text(stringResource(R.string.ui_settings_export_data)) },
+                supportingContent = { Text(stringResource(R.string.ui_settings_export_description)) },
+                colors = transparentListItem(),
+                modifier = Modifier.clickable { showExportDialog = true },
+            )
+        }
+    }
 
-        // --- Export Data Section ---
-        var showExportOptions by remember { mutableStateOf(false) }
-        var includeContext by remember { mutableStateOf(true) }
-        var includeDismissed by remember { mutableStateOf(false) }
-
-        Text(
-            stringResource(R.string.ui_settings_export_data),
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            style = androidx.compose.material3.MaterialTheme.typography.titleMedium
+    if (showLanguagePicker) {
+        ExtractionLanguagePickerDialog(
+            selected = extractionLanguage,
+            originalLabel = originalLabel,
+            onSelect = { value ->
+                extractionLanguage = value
+                SharedPreferencesManager.targetExtractionLanguage = value
+                showLanguagePicker = false
+            },
+            onDismiss = { showLanguagePicker = false },
         )
+    }
 
-        Text(
-            stringResource(R.string.ui_settings_export_description),
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-            style = androidx.compose.material3.MaterialTheme.typography.bodySmall
+    if (showExportDialog) {
+        ExportDataDialog(
+            onDismiss = { showExportDialog = false },
+            onExport = { includeContext, includeDismissed ->
+                drawerViewModel.exportAllData(includeContext, includeDismissed)
+                showExportDialog = false
+            },
         )
+    }
+}
 
-        // Export options
-        if (!showExportOptions) {
-            Button(
-                onClick = { showExportOptions = true },
-                modifier = Modifier
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .fillMaxWidth()
-            ) {
-                Text(stringResource(R.string.ui_settings_export_data))
-            }
-        } else {
-            // Show options when expanded
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Checkbox(
+/** A titled group of settings rows rendered as one neutral card with hairline dividers. */
+@Composable
+private fun SettingsSection(title: String, content: @Composable () -> Unit) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 28.dp, end = 28.dp, top = Dimens.element, bottom = 6.dp),
+    )
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Dimens.screenH),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column { content() }
+    }
+}
+
+@Composable
+private fun RowDivider() {
+    HorizontalDivider(
+        modifier = Modifier.padding(start = 16.dp),
+        color = MaterialTheme.colorScheme.outlineVariant,
+    )
+}
+
+@Composable
+private fun transparentListItem() =
+    ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+
+/** Export options as a confirm dialog (was an inline expanding section). */
+@Composable
+private fun ExportDataDialog(
+    onDismiss: () -> Unit,
+    onExport: (includeContext: Boolean, includeDismissed: Boolean) -> Unit,
+) {
+    var includeContext by remember { mutableStateOf(true) }
+    var includeDismissed by remember { mutableStateOf(false) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.ui_settings_export_data)) },
+        text = {
+            Column {
+                CheckRow(
                     checked = includeContext,
-                    onCheckedChange = { includeContext = it }
+                    onCheckedChange = { includeContext = it },
+                    label = stringResource(R.string.ui_settings_export_include_context),
                 )
-                Text(
-                    stringResource(R.string.ui_settings_export_include_context),
-                    modifier = Modifier.padding(start = 8.dp)
-                )
-            }
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Checkbox(
+                CheckRow(
                     checked = includeDismissed,
-                    onCheckedChange = { includeDismissed = it }
-                )
-                Text(
-                    stringResource(R.string.ui_settings_export_include_dismissed),
-                    modifier = Modifier.padding(start = 8.dp)
+                    onCheckedChange = { includeDismissed = it },
+                    label = stringResource(R.string.ui_settings_export_include_dismissed),
                 )
             }
+        },
+        confirmButton = {
+            TextButton(onClick = { onExport(includeContext, includeDismissed) }) {
+                Text(stringResource(R.string.ui_action_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.ui_action_cancel)) }
+        },
+    )
+}
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)
-            ) {
-                Button(
-                    onClick = {
-                        drawerViewModel.exportAllData(includeContext, includeDismissed)
-                        showExportOptions = false
-                    },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text(stringResource(R.string.ui_action_ok))
-                }
-                TextButton(
-                    onClick = { showExportOptions = false },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text(stringResource(R.string.ui_action_cancel))
-                }
-            }
-        }
+@Composable
+private fun CheckRow(checked: Boolean, onCheckedChange: (Boolean) -> Unit, label: String) {
+    androidx.compose.foundation.layout.Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(selected = checked, onClick = { onCheckedChange(!checked) }, role = Role.Checkbox)
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(checked = checked, onCheckedChange = onCheckedChange)
+        Text(label, modifier = Modifier.padding(start = 8.dp))
     }
 }
 
@@ -339,7 +316,7 @@ private fun ExtractionLanguagePickerDialog(
 
 @Composable
 private fun LanguageRow(label: String, selected: Boolean, onClick: () -> Unit) {
-    Row(
+    androidx.compose.foundation.layout.Row(
         modifier = Modifier
             .fillMaxWidth()
             .selectable(selected = selected, onClick = onClick, role = Role.RadioButton)
@@ -350,4 +327,3 @@ private fun LanguageRow(label: String, selected: Boolean, onClick: () -> Unit) {
         Text(label, modifier = Modifier.padding(start = 8.dp))
     }
 }
-

--- a/app/src/main/java/org/muilab/notigpt/ui/theme/Color.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/theme/Color.kt
@@ -8,6 +8,12 @@ import androidx.compose.ui.graphics.Color
  * The palette is intentionally neutral so that the *semantic* colors (section accents and deadline urgency,
  * see [NotiSemanticColors]) carry the meaning. A single calm indigo serves as the primary/selected-state hue.
  * Keep raw hex values here; map them into [androidx.compose.material3.ColorScheme] roles in Theme.kt.
+ *
+ * Surface-role policy (Apple-restraint direction): the app canvas is `surface` (the lightest role);
+ * list cards sit on `surfaceContainerLow` and the live NotiCard on `surfaceBright`, so cards separate
+ * from the canvas by a subtle step rather than by tinting. Fully tinted container fills
+ * (`primaryContainer`, task/keep containers) are reserved for at most one hero element per screen;
+ * elsewhere, meaning is carried by colored icons/accents/counts on neutral bodies.
  */
 
 // ── Light scheme — neutral chrome + indigo primary ───────────────────────────

--- a/app/src/main/java/org/muilab/notigpt/ui/theme/Dimens.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/theme/Dimens.kt
@@ -1,0 +1,33 @@
+package org.muilab.notigpt.ui.theme
+
+import androidx.compose.ui.unit.dp
+
+/**
+ * Spacing scale for the app, on a 4-pt grid.
+ *
+ * The refinement direction favours whitespace-driven hierarchy over container tinting, so these tokens
+ * intentionally lean generous (section gaps, card inner padding). Use them instead of literal `.dp`
+ * paddings in `ui/` so screens share one rhythm. Keep values here; reference as `Dimens.screenH` etc.
+ */
+object Dimens {
+    /** Horizontal gutter for all list/screen content. */
+    val screenH = 16.dp
+
+    /** Vertical gap between stacked cards in a list. */
+    val cardOuterV = 6.dp
+
+    /** Inner padding inside a card body. */
+    val cardInner = 16.dp
+
+    /** Gap above a section (header + content block). */
+    val sectionTop = 28.dp
+
+    /** Gap between a section header and its first item. */
+    val sectionHeaderBottom = 8.dp
+
+    /** Small inline gap (icon↔text, chip↔chip). */
+    val inline = 8.dp
+
+    /** Medium gap between related elements within a card. */
+    val element = 12.dp
+}

--- a/app/src/main/java/org/muilab/notigpt/ui/theme/Motion.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/theme/Motion.kt
@@ -1,0 +1,37 @@
+package org.muilab.notigpt.ui.theme
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+
+/**
+ * Shared motion vocabulary.
+ *
+ * Anything a finger touches settles on a spring (natural, interruptible); pure fades use short tweens.
+ * Replaces scattered `tween(200)/tween(250)` across cards, the review stack, and the top bar so motion
+ * reads as one system. Springs are hand-rolled here rather than pulled from `MotionScheme` to stay off
+ * the material3 alpha's expressive-theme surface; swap to `MotionScheme` tokens later if adopted.
+ */
+object MotionSpecs {
+    /** Offset / expansion settle — card drag release, anchored-drawer snap. */
+    fun <T> settle(): AnimationSpec<T> = spring(
+        dampingRatio = Spring.DampingRatioLowBouncy,
+        stiffness = Spring.StiffnessMediumLow,
+    )
+
+    /** Stiffer settle for small controls (button press, chip select). */
+    fun <T> snappy(): AnimationSpec<T> = spring(
+        dampingRatio = Spring.DampingRatioNoBouncy,
+        stiffness = Spring.StiffnessMedium,
+    )
+
+    /** Review-card fly-off after a committed swipe. */
+    fun <T> flyOff(): AnimationSpec<T> = tween(durationMillis = 260)
+
+    /** Alpha-only cross-fades (search bar, title swaps). */
+    fun <T> quick(): AnimationSpec<T> = tween(durationMillis = 180)
+
+    /** Screen push/pop + menu fade-through duration, in ms. */
+    const val ScreenTransitionMs = 280
+}

--- a/app/src/main/java/org/muilab/notigpt/ui/theme/Shape.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/theme/Shape.kt
@@ -1,0 +1,26 @@
+package org.muilab.notigpt.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+/**
+ * App shape scale, wired into [androidx.compose.material3.MaterialTheme.shapes].
+ *
+ * One scale for the whole app so corner radii stop drifting (previously 6/8/12/14/16/20 dp ad-hoc).
+ * Reference via `MaterialTheme.shapes.medium` etc. — no literal `RoundedCornerShape` in `ui/` outside
+ * this file.
+ *
+ * - extraSmall  6dp — badges, tiny inline chips
+ * - small      10dp — chips, inline surfaces
+ * - medium     14dp — list cards (ReminderCard, category rows)
+ * - large      18dp — hero cards, bottom sheets, NotiCard
+ * - extraLarge 26dp — dialogs, review cards
+ */
+val NotiShapes = Shapes(
+    extraSmall = RoundedCornerShape(6.dp),
+    small = RoundedCornerShape(10.dp),
+    medium = RoundedCornerShape(14.dp),
+    large = RoundedCornerShape(18.dp),
+    extraLarge = RoundedCornerShape(26.dp),
+)

--- a/app/src/main/java/org/muilab/notigpt/ui/theme/Theme.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package org.muilab.notigpt.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
@@ -12,11 +11,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 import org.muilab.notigpt.util.SharedPreferencesManager
 
 private val DarkColorScheme = darkColorScheme(
@@ -128,19 +123,14 @@ fun NotiTheme(
 
     val notiColors = if (darkTheme) DarkNotiColors else LightNotiColors
 
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.surface.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
-        }
-    }
+    // System-bar appearance (transparent bars + light/dark icons) is handled by enableEdgeToEdge in
+    // MainActivity, which reacts to the system dark-mode setting. No manual statusBarColor here.
 
     CompositionLocalProvider(LocalNotiColors provides notiColors) {
         MaterialTheme(
             colorScheme = colorScheme,
             typography = Typography,
+            shapes = NotiShapes,
             content = content,
         )
     }

--- a/app/src/main/java/org/muilab/notigpt/ui/theme/Type.kt
+++ b/app/src/main/java/org/muilab/notigpt/ui/theme/Type.kt
@@ -1,6 +1,9 @@
 package org.muilab.notigpt.ui.theme
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -77,3 +80,27 @@ val Typography = Typography(
         fontSize = 11.sp, lineHeight = 16.sp, letterSpacing = 0.5.sp,
     ),
 )
+
+/**
+ * App-level named styles built on the M3 scale.
+ *
+ * These exist so screens stop applying ad-hoc `fontWeight = FontWeight.SemiBold/Bold` overrides: a
+ * card title or a stat number is one named style, retunable in one place. Reference as
+ * `NotiType.cardTitle` etc. inside composables.
+ */
+object NotiType {
+    /** Card headline (NotiCard / ReminderCard title). Slightly heavier than titleMedium. */
+    val cardTitle: TextStyle
+        @Composable @ReadOnlyComposable
+        get() = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+
+    /** Big count in a stat box / smart-filter tile. */
+    val statNumber: TextStyle
+        @Composable @ReadOnlyComposable
+        get() = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.SemiBold)
+
+    /** Metadata line (timestamp, counts) — pair with `onSurfaceVariant`. */
+    val metadata: TextStyle
+        @Composable @ReadOnlyComposable
+        get() = MaterialTheme.typography.labelMedium
+}

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Launch/window background, dark mode. Matches DarkSurface in Color.kt. -->
+    <color name="splash_background">#121316</color>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -392,6 +392,12 @@
     <string name="menu_history">歷史記錄</string>
     <string name="menu_section_collections">收藏</string>
     <string name="menu_section_more">更多</string>
+    <string name="scheduled_reminder_time">提醒時間：%1$s</string>
+    <string name="scheduled_pick_time">選擇時間</string>
+    <string name="settings_section_appearance">外觀</string>
+    <string name="settings_section_extraction">擷取</string>
+    <string name="settings_section_data">資料</string>
+    <string name="home_reminders_due">%1$d 個提醒到期</string>
     <string name="noti_clear_all_confirm_title">清除通知？</string>
     <string name="noti_clear_all_confirm_message">這會移除目前清單中顯示的通知，已釘選的通知會保留。</string>
     <string name="a11y_more_actions">更多動作</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -390,6 +390,8 @@
     <string name="menu_home">主頁</string>
     <string name="menu_reminders">排程提醒</string>
     <string name="menu_history">歷史記錄</string>
+    <string name="menu_section_collections">收藏</string>
+    <string name="menu_section_more">更多</string>
     <string name="a11y_more_actions">更多動作</string>
 
     <!-- New screen sections + triage -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -392,6 +392,8 @@
     <string name="menu_history">歷史記錄</string>
     <string name="menu_section_collections">收藏</string>
     <string name="menu_section_more">更多</string>
+    <string name="noti_clear_all_confirm_title">清除通知？</string>
+    <string name="noti_clear_all_confirm_message">這會移除目前清單中顯示的通知，已釘選的通知會保留。</string>
     <string name="a11y_more_actions">更多動作</string>
 
     <!-- New screen sections + triage -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,7 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <!-- Launch/window background, light mode. Matches LightSurface in Color.kt. -->
+    <color name="splash_background">#FBFBFC</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -422,6 +422,8 @@
     <string name="menu_history">History</string>
     <string name="menu_section_collections">Collections</string>
     <string name="menu_section_more">More</string>
+    <string name="noti_clear_all_confirm_title">Clear notifications?</string>
+    <string name="noti_clear_all_confirm_message">This removes the notifications currently shown in this list. Pinned notifications are kept.</string>
     <string name="a11y_more_actions">More actions</string>
 
     <!-- New screen sections + triage -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,11 @@
     <string name="ui_settings_extraction_language_zhtw">繁體中文 (zh-TW)</string>
     <string name="ui_settings_extraction_language_search">Search languages</string>
 
+    <string name="scheduled_reminder_time">Reminder time: %1$s</string>
+    <string name="scheduled_pick_time">Pick time</string>
+    <string name="settings_section_appearance">Appearance</string>
+    <string name="settings_section_extraction">Extraction</string>
+    <string name="settings_section_data">Data</string>
     <string name="ui_settings_export_data">Export Data</string>
     <string name="ui_settings_export_description">Export all notifications and user actions</string>
     <string name="ui_settings_export_include_dismissed">Include dismissed notifications</string>
@@ -422,6 +427,7 @@
     <string name="menu_history">History</string>
     <string name="menu_section_collections">Collections</string>
     <string name="menu_section_more">More</string>
+    <string name="home_reminders_due">%1$d reminders due</string>
     <string name="noti_clear_all_confirm_title">Clear notifications?</string>
     <string name="noti_clear_all_confirm_message">This removes the notifications currently shown in this list. Pinned notifications are kept.</string>
     <string name="a11y_more_actions">More actions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -420,6 +420,8 @@
     <string name="menu_home">Home</string>
     <string name="menu_reminders">Reminders</string>
     <string name="menu_history">History</string>
+    <string name="menu_section_collections">Collections</string>
+    <string name="menu_section_more">More</string>
     <string name="a11y_more_actions">More actions</string>
 
     <!-- New screen sections + triage -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.NotiTask" parent="android:Theme.Material.Light.NoActionBar" />
+    <!-- Launch theme: shows the app icon on a solid window background via the SplashScreen API,
+         then hands off to the post-splash theme. DayNight background (see values-night) so a
+         dark-mode cold start has no white flash. -->
+    <style name="Theme.NotiTask.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/splash_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="postSplashScreenTheme">@style/Theme.NotiTask</item>
+    </style>
+
+    <!-- App theme: edge-to-edge, no title bar. Compose owns all UI colors; this platform DayNight
+         parent (no Material Components dependency needed) only provides a mode-correct window
+         background for pre-Compose frames. enableEdgeToEdge() in MainActivity handles the
+         transparent system bars and icon contrast. -->
+    <style name="Theme.NotiTask" parent="@android:style/Theme.DeviceDefault.DayNight">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowBackground">@color/splash_background</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+
 </resources>

--- a/docs/plans/ui-refinement-plan.md
+++ b/docs/plans/ui-refinement-plan.md
@@ -1,0 +1,285 @@
+# UI Refinement Plan — Native Android, Apple-calibre polish
+
+**Status:** approved direction, ready for execution
+**Written:** 2026-07-13 (post main-interface redesign, commit `24cce29`)
+**Executor notes:** designed to be executed phase-by-phase, each phase independently buildable and shippable. Read the whole document before starting Phase 1; the Feature Preservation Contract (§9) applies to every phase.
+
+---
+
+## 1. Design brief
+
+The goal is **an Android app that feels as polished, thoughtful, and cohesive as the best Apple apps while remaining unmistakably native to Android.**
+
+- **Interaction model: Android.** Material 3 + Compose foundation, system back / predictive back, Material components (snackbars, FABs, chips, sheets, menus), Android gestures, TalkBack accessibility, optional dynamic color.
+- **Visual language: Apple-influenced restraint.** Generous whitespace, typography-driven hierarchy, hairline dividers, *minimal container tinting*, quiet chrome, content forward.
+- **M3 Expressive: selectively.** The project is on `material3 1.5.0-alpha20`, which ships the Expressive APIs. Use Expressive *motion* (spring-based feedback on presses, toggles, swipes, expansion) and isolated components (`LoadingIndicator`) where they add life. Do **not** adopt the Expressive *aesthetic* wholesale (no giant shape morphs, no bold tonal blocking, no FlexibleBottomAppBar).
+
+### Product context the design must serve
+
+This app is the user's **primary notification surface** — notifications are removed from the system drawer. Two coequal primary needs:
+1. **Extracted items** (Tasks/Keep) for quick understanding and task management.
+2. **Original notifications** for verification and micro-tasks (e.g. replying) that don't warrant extraction.
+
+Secondary: preference elicitation (chat), settings, notification history. Scheduled (alarm) reminders sit between primary and secondary — see §10 Open item.
+
+### Settled decisions (do not relitigate)
+
+- **IA is settled**: home portal + explicit back stack + hamburger drawer for secondary sections ([AppDestinations.kt](../../app/src/main/java/org/muilab/notigpt/ui/common/navigation/AppDestinations.kt), [AppScaffold.kt](../../app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt)). No bottom bar. Polish, don't restructure.
+- **Semantic color layer stays** ([SemanticColor.kt](../../app/src/main/java/org/muilab/notigpt/ui/theme/SemanticColor.kt)): Tasks/Keep identity and overdue/due-soon urgency keep fixed meanings independent of dynamic color. What changes is *how much surface area* those colors paint (§3.4).
+- **Card interactions may be redesigned, but zero feature loss** across NotiCard, Review cards, and Task/Keep (Reminder) cards. §9 is the binding inventory.
+- **The 2026-07-13 swipe-intent fix is sacred**: angle-only horizontal intent (`absX > absY*1.05`) in [NotiCardSwipe.kt](../../app/src/main/java/org/muilab/notigpt/ui/notification/component/card/noticard/elements/NotiCardSwipe.kt), and drawer `gesturesEnabled = drawerState.isOpen`. Any change touching these must re-verify slow horizontal swipes still work.
+
+---
+
+## 2. Current-state audit (what's wrong, concretely)
+
+| # | Issue | Where |
+|---|-------|-------|
+| 1 | No edge-to-edge; deprecated `window.statusBarColor`; XML theme is light-only `Theme.Material.Light.NoActionBar` → white flash on dark-mode launch, no splash screen | [Theme.kt:135](../../app/src/main/java/org/muilab/notigpt/ui/theme/Theme.kt), `res/values/themes.xml`, [MainActivity.kt](../../app/src/main/java/org/muilab/notigpt/MainActivity.kt) |
+| 2 | `Toast`s everywhere (≈10 call sites incl. ViewModels) where snackbars belong | RemindersScreen, NotificationHistoryScreen, PreferenceViewModel, NotiFeedbackDropdown, MainActivity, UserControlPanel; `ToastUserToaster` |
+| 3 | No screen transitions — destinations hard-switch in a `when`; no predictive-back animation | [AppScaffold.kt:320-377](../../app/src/main/java/org/muilab/notigpt/ui/common/component/AppScaffold.kt) |
+| 4 | Corner radii ad-hoc: 6/8/12/14/16/20 dp scattered; `MaterialTheme.shapes` only used by NotiCard | HomeScreen, ReviewScreen, ReminderCard, badges |
+| 5 | Margins inconsistent: screens use 16 dp, NotiCard uses 20 dp; card inner paddings vary 10–20 dp | NotiCard vs ReminderCard vs Home |
+| 6 | Ad-hoc `FontWeight.SemiBold/Bold` overrides instead of type-scale variants | HomeScreen, ReviewScreen |
+| 7 | Hardcoded colors: `Color.Red` drawer badge, pin blue `Color(76,139,245)`, black/white rim alphas on NotiCard | AppDrawerContent:68, NotiCardOverlayButtons:140, NotiCard:212 |
+| 8 | NotiCard visual clutter: outline border (1 dp, 3 dp when sorted) *plus* a second rim border | NotiCard:118, 212-213 |
+| 9 | Long-press `AlertDialog` as card options menu — undiscoverable, non-idiomatic | NotiCardOptionsDialog, NotificationHistoryScreen:279 |
+| 10 | Settings screen is ad-hoc rows: no `ListItem`, radio row aligned with a `top = 12.dp` text hack, export options expand inline | [SettingScreen.kt](../../app/src/main/java/org/muilab/notigpt/ui/settings/SettingScreen.kt) |
+| 11 | Drawer reuses the `task` icon for Tasks, Reminders, *and* Preferences; no header; no section labels | [AppDrawerContent.kt](../../app/src/main/java/org/muilab/notigpt/ui/common/component/AppDrawerContent.kt) |
+| 12 | `RemindersScreen.kt` is a 2,353-line monolith (screen + card + detail editor + 4 dialogs) — unsafe to edit | [RemindersScreen.kt](../../app/src/main/java/org/muilab/notigpt/ui/reminder/screen/RemindersScreen.kt) |
+| 13 | Gesture surfaces (swipe, drag-expand, review fling) have no TalkBack custom actions | NotiCard, ReviewCardStack |
+| 14 | Motion is scattered `tween(200/250)`; no shared spec; haptics only in ReminderCard | throughout |
+| 15 | Review stack uses `LocalConfiguration.current.screenWidthDp` (deprecated pattern) and tween-based fling | ReviewCardStack |
+
+---
+
+## 3. Phase 1 — Foundations (tokens, theme, platform hygiene)
+
+Everything later depends on this phase. No visual redesign of screens yet; this phase makes the vocabulary exist.
+
+### 3.1 Shape scale
+Define in `Theme.kt` via `MaterialTheme(shapes = …)`:
+- `extraSmall` 6 dp (badges, tiny chips) · `small` 10 dp (chips, inline surfaces) · `medium` 14 dp (list cards) · `large` 18 dp (hero cards, sheets) · `extraLarge` 26 dp (dialogs, review cards).
+Replace **every** literal `RoundedCornerShape(n.dp)` in `ui/` with a `MaterialTheme.shapes` reference. Grep check must return zero literals outside `theme/` when done.
+
+### 3.2 Spacing scale
+New file `ui/theme/Dimens.kt`: 4-pt grid tokens —
+`ScreenHPadding = 16.dp`, `CardOuterVGap = 6.dp`, `CardInnerPadding = 16.dp`, `SectionTopGap = 28.dp`, `SectionHeaderBottomGap = 8.dp`, `InlineGap = 8.dp`, `ElementGap = 12.dp`.
+Unify: NotiCard outer horizontal margin 20 dp → `ScreenHPadding`; all list screens share identical gutters. "Generous whitespace" = raise vertical rhythm (section gaps 28 dp, card inner padding 16 dp) rather than shrinking content.
+
+### 3.3 Typography usage rules
+Keep the existing full M3 scale in [Type.kt](../../app/src/main/java/org/muilab/notigpt/ui/theme/Type.kt) (system font, CJK fallback). Add two app-level styles to `Type.kt` instead of scattered overrides:
+- `Typography.titleMediumEmphasized`-equivalent: extend via extension vals (e.g. `val Typography.cardTitle` = titleMedium @ SemiBold) — then **delete every ad-hoc `fontWeight =` override in screens** and reference the named styles.
+Rules to apply in later phases: screen/section titles = title styles; card titles = `cardTitle`; metadata (time, counts) = `labelMedium` in `onSurfaceVariant`; body previews = `bodyMedium`. Numbers in stat boxes = `headlineMedium` (not Large+Bold).
+
+### 3.4 Color usage policy — "restrained tinting"
+The single biggest Apple-restraint lever. Policy (enforced screen-by-screen in later phases):
+- **Neutral surfaces by default.** Cards: `surfaceContainerLow` (lists) / `surfaceBright` (NotiCard ok). Full tinted-container fills (`primaryContainer`, `taskContainer`…) are reserved for **at most one hero element per screen** (e.g. the home Review row).
+- **Semantics move from fills to accents**: colored icon-in-circle, colored count text, 3 dp leading accent bar, colored chip *outline/label* — on neutral card bodies. (Apple Reminders pattern: gray boxes, colored icon disc + big count.)
+- **Dividers**: `outlineVariant` hairlines (0.5–1 dp), used sparingly; prefer whitespace.
+- **Kill hardcoded colors**: drawer badge → `MaterialTheme.colorScheme.error`; pin-active tint → `colorScheme.primary`; NotiCard rim hack → delete (single hairline border instead, §6.1).
+- Urgency (`overdue`/`dueSoon`) keeps container fills **only inside DueChip**, nowhere larger.
+
+### 3.5 Edge-to-edge, splash, dark launch
+- `enableEdgeToEdge()` in `MainActivity.onCreate`; delete the `window.statusBarColor` SideEffect in `Theme.kt`; handle insets via `Scaffold` paddings + `WindowInsets` on the drawer sheet, top bar, sheets, and IME where needed.
+- `themes.xml`: replace with a `Theme.SplashScreen`-parented DayNight theme (androidx core-splashscreen), `postSplashScreenTheme` → a DayNight NoActionBar theme, dark `windowBackground` in `values-night/`. Add app icon as splash mark.
+- Verify: launch in dark mode has no white flash; status/nav bars are transparent; content draws behind system bars with correct insets on API 29 (gesture nav + 3-button).
+
+### 3.6 Motion spec
+New file `ui/theme/Motion.kt`:
+- `MotionSpecs.settle` (spring, medium damping) for offset/expansion settles; `MotionSpecs.flyOff` for review commit; `MotionSpecs.fadeThrough` for screen transitions; `MotionSpecs.quick` (150–200 ms) for alpha-only.
+- Replace scattered `tween(200)/tween(250)` in NotiCard, ReviewCardStack, AppTopBar with these tokens. Springs for anything the finger touches; tweens only for pure fades. If adopting `MaterialExpressiveTheme` + `MotionScheme` proves low-friction on this alpha, prefer that as the source of the spring tokens; otherwise hand-rolled `spring()` specs are fine — decide once, in this file.
+
+### 3.7 Haptics
+New `ui/common/feedback/Haptics.kt`: semantic wrappers (`confirmToggle`, `commitSwipe`, `thresholdCross`, `longPress`). Wire in later phases: NotiCard swipe commit, review commit + threshold cross, checkbox/star/archive toggles (already partially in ReminderCard — route through the helper), drag-to-reorder pickup.
+
+### 3.8 Feedback unification (Toast → Snackbar)
+- Add an app-scoped `SnackbarHostState` owned by `AppScaffold` (one already exists for preference events — generalize it): a small `AppMessageBus` (SharedFlow of message events) that ViewModels emit into; `AppScaffold` collects and shows snackbars.
+- Convert all UI-layer `Toast.makeText` call sites (§2 item 2). `ToastUserToaster` gets a snackbar-backed implementation (`UserToaster` interface stays).
+- Keep genuine system-context toasts only where the app UI may not be visible (none currently qualify except possibly service-level code — out of UI scope).
+
+**Phase-1 verification:** `./gradlew :app:assembleDebug :app:testDebugUnitTest` green; app launches edge-to-edge light+dark; no visual regressions beyond intended (screens still render with old layouts on new tokens).
+
+---
+
+## 4. Phase 2 — App shell (top bar, drawer, transitions, search)
+
+### 4.1 Screen transitions + predictive back
+- Wrap the destination `when` in `AppScaffold` in `AnimatedContent` keyed on `(menuScreen, currentDest)`: push = slide-in-from-end + fade; pop = reverse; menu screens = fade-through (`MotionSpecs.fadeThrough`).
+- Replace the plain `BackHandler` with `PredictiveBackHandler` so the pop transition scrubs with the back gesture (Android-native polish; this is exactly the "unmistakably Android" part).
+- Verify `android:enableOnBackInvokedCallback="true"` in the manifest.
+
+### 4.2 Top bar
+- Home root: switch to `LargeTopAppBar` ("Noti" large title collapsing to small on scroll) — Material-native component, Apple-large-title feel. Pushed screens keep small `TopAppBar` + back arrow.
+- Scroll edge treatment: keep `containerColor = surface` and add a hairline bottom divider that fades in when content is scrolled (instead of tonal `scrolledContainerColor` tint) — restrained chrome.
+- Search stays the in-bar expandable pattern; restyle the field in [SearchBar.kt](../../app/src/main/java/org/muilab/notigpt/ui/common/component/SearchBar.kt): borderless, `bodyLarge`, subtle placeholder, clear (×) button, auto-focus with IME on expand.
+
+### 4.3 Drawer
+[AppDrawerContent.kt](../../app/src/main/java/org/muilab/notigpt/ui/common/component/AppDrawerContent.kt):
+- Header: app name (+ signed-in account email, small, `onSurfaceVariant`).
+- Distinct icons: Tasks `task`, Keep `keep`/bookmark, Reminders `schedule`/alarm icon, Preferences a chat/tune icon, History `history`, Settings `settings`. Add drawable assets if missing.
+- Section structure: Home · **Collections** (Tasks, Keep) · divider · **More** (Reminders, Preferences, History, Settings), with `labelMedium` section headers.
+- Badges: counts as plain `Text` badge (current style) but the Reminders badge uses `colorScheme.error` via `Badge()` defaults — no `Color.Red`.
+- `NavigationDrawerItem` with `NavigationDrawerItemDefaults.ItemPadding`; drawer sheet gets proper status-bar inset after §3.5.
+
+### 4.4 Scaffold container
+- `containerColor`: keep a subtle canvas/card separation — `surfaceContainerLowest`-on-cards over `surface` canvas *or* current `surfaceDim`; pick one and apply globally (recommend: canvas `surface`, cards `surfaceContainerLow`, NotiCard `surfaceBright` in dark / `surfaceContainerLowest` in light). Document the choice in `Color.kt`'s header comment.
+
+**Verification:** navigate through all destinations — transitions run both directions, predictive back scrubs, drawer opens only via hamburger (regression check!), search works on the 4 searchable screens, badges correct.
+
+---
+
+## 5. Phase 3 — Home screen
+
+[HomeScreen.kt](../../app/src/main/java/org/muilab/notigpt/ui/home/HomeScreen.kt). Layout order stays: Review row → Notifications → Saved. Restyle per §3.4:
+
+- **Review row** — the screen's one hero: keeps `primaryContainer` fill, `shapes.large`, icon + two-line text + count badge. Slightly larger padding (20 dp), count in `titleMedium`.
+- **Notification category rows** (Communication / Content): neutral `surfaceContainerLow` cards; app-icon preview lines get 2 lines max with per-sender counts (as now); unread count becomes a **filled small badge** (primary or neutral) right-aligned; whole row min-height ≥ 72 dp for touch comfort. These rows are the fast path to the primary notification surface — visually calm but first-class.
+- **Smart-filter grid**: Apple Reminders treatment — neutral `surfaceContainerLow` boxes; each gets a **small colored icon disc** (task/keep/dueSoon/neutral accents) top-left, big count `headlineMedium` top-right, label + type-breakdown bottom. Kills 4 different tinted fills, preserves color semantics in the discs/counts. Undetermined keeps its full-width row, neutral.
+- **Section headers**: `titleSmall`+`onSurfaceVariant` (as now) but with §3.2 rhythm (28 dp top gap).
+- Home scrolls under the collapsing large-title bar (§4.2).
+
+**Verification:** counts match drawer badges; tap targets all navigate; light/dark/dynamic-color all render (semantic discs must stay fixed under dynamic color).
+
+---
+
+## 6. Phase 4 — Notification surfaces (NotiCard, category pages, history)
+
+### 6.1 NotiCard visual reskin (gesture logic untouched)
+[NotiCard.kt](../../app/src/main/java/org/muilab/notigpt/ui/notification/component/card/noticard/NotiCard.kt) + `elements/`:
+- **One border, not three looks**: drop the rim hack (`Color.White/Black` alphas) and the outline border; use `surfaceBright` (dark) / `surfaceContainerLowest` (light) with a single 0.5–1 dp `outlineVariant` hairline. Sort-position highlight (`borderWidth 3.dp`) → replace with a `primary` hairline + slight scale (existing `scaleValue` already does 1.02 on drag).
+- Outer margin → `ScreenHPadding` (16 dp); vertical gap between cards 6 dp; inner padding from `Dimens`.
+- Header hierarchy: app icon, then title (`cardTitle`), secondary title `bodyMedium`/`onSurfaceVariant`, timestamp `labelMedium` right-aligned, summary `bodyMedium` (keep the collapse-threshold-driven summary/title swap logic exactly as is).
+- Pin state: pinned tint = `colorScheme.primary` (kill `Color(76,139,245)`); pinned cards may also show a tiny pin glyph next to the timestamp.
+- Expanded records: hairline dividers between records, sender `labelLarge`, content `bodyMedium`, time `labelSmall`; keep anchored-drag + fling behavior and the measured-anchors logic untouched.
+
+### 6.2 NotiCard options: dialog → bottom sheet (feature-preserving)
+Replace `NotiCardOptionsDialog` (AlertDialog of TextButtons) with a `ModalBottomSheet` of `ListItem`s: Pin/Unpin · Extract task · Create scheduled reminder (when available). Long-press still opens it; **additionally** add a small overflow affordance inside the expanded state or keep long-press as the only entry — but the sheet itself must list every current action (§9.1). The commented-out "dismiss" action stays out (it was deliberately removed).
+
+### 6.3 Swipe visuals
+Background action panel ([NotiCardActions.kt](../../app/src/main/java/org/muilab/notigpt/ui/notification/component/card/noticard/elements/NotiCardActions.kt)): restyle as icon-in-circle buttons on a neutral background strip; alpha ramp stays. Add `Haptics.commitSwipe` when the archive threshold commits. **Do not touch** `NotiCardSwipe.kt` intent logic.
+
+### 6.4 Accessibility on gestures
+Add `Modifier.semantics { customActions = … }` on the card root: Archive, Pin/Unpin, Expand/Collapse, Extract task, Create reminder — so TalkBack users can invoke everything swipe/drag provides. Same for review cards (§8) with Approve/Reject/Open details.
+
+### 6.5 Category screens + history
+- [NotiCategoryScreen.kt](../../app/src/main/java/org/muilab/notigpt/ui/notification/screen/NotiCategoryScreen.kt): filter chips (All / last-24h) restyled per token pass; empty states via `EmptyState`; the top-bar **Clear-all** action gets an **undo snackbar** (route through §3.8 bus) instead of silent execution — verify `clearVisibleNotis` supports restore, otherwise keep a confirm dialog. Zero data-loss risk allowed here.
+- [NotificationHistoryScreen.kt](../../app/src/main/java/org/muilab/notigpt/ui/notification/screen/NotificationHistoryScreen.kt): Grouped/Timeline chips stay; the long-press AlertDialog (Copy / Extract) → bottom sheet or `DropdownMenu`, same items; toasts → snackbars.
+- `AutoControlBar` / `UserControlPanel` / `DevControlPanel` (dev-facing strips): minimal restyle only (switch rows via `ListItem`), lowest priority.
+
+**Verification:** every §9.1 feature exercised on device; slow horizontal swipe still archives; expand-drag and pin-button exclusion zones still work; TalkBack reads and performs custom actions.
+
+---
+
+## 7. Phase 5 — Saved items (split, then redesign)
+
+### 7.0 Pre-refactor (its own PR, zero behavior change)
+Split [RemindersScreen.kt](../../app/src/main/java/org/muilab/notigpt/ui/reminder/screen/RemindersScreen.kt) (2,353 lines):
+- `reminder/screen/RemindersScreen.kt` — list screen + chips row + FAB + wiring only
+- `reminder/component/ReminderCard.kt` — card (+ `CardDoDatePickerDialog`, `DoDateBottomButton`, `ReminderActionChip`)
+- `reminder/screen/ReminderDetailScreen.kt` — detail editor (+ its pickers, header menu)
+- `reminder/component/ExportConfirmationDialog.kt`
+Keep signatures; move-only. Verify build + unit tests + a manual list/edit/save round-trip before any restyle.
+
+### 7.1 ReminderCard (Task/Keep card) reskin
+All features preserved (§9.2). Restyle:
+- Neutral `surfaceContainerLow`, `shapes.medium`, 0.5 dp hairline; 3 dp `sectionAccent` leading bar stays (it *is* the restrained semantic marker).
+- Bottom icon row is crowded (star / schedule / export / delete + do-date). Consolidate: keep **do-date chip + star** inline; move **set-reminder, export, delete** into a trailing overflow `DropdownMenu` (⋮) on the bottom row. Delete keeps its confirm dialog for reviewed items. If testing shows the overflow hurts (heavy daily actions), fall back to current 4-icon row with tightened spacing — either way all five actions remain reachable in ≤ 2 taps.
+- New/Updated badge: `labelSmall` on `secondaryContainer` (as now) but shape `extraSmall`.
+- Completed task: strikethrough + `onSurfaceVariant` title (add the dimming).
+
+### 7.2 Detail editor
+Currently a bespoke full-screen column. Restyle toward an iOS-grouped-list feel with Material parts:
+- Top bar: back, borderless title field (as now, restyled), ⋮ menu (Regenerate / Delete) stays a `DropdownMenu`.
+- Body groups as **cards of grouped rows** (`surfaceContainerLow`, hairline dividers): Type+Completed · Deadline (date/time rows) · Do-date (date/time/Someday chip/clear) · Note · LLM action chips · Sub-tasks · Reminder+Export+Share chips · Change history · Related notifications.
+- Date/time pickers stay M3 `DatePickerDialog`/TimePicker.
+- Keep the save-on-back contract (`onBack(buildUpdated())`) exactly.
+
+### 7.3 List screen
+- Filter chips row: standard `FilterChip` styling from token pass; the chip "flash" affordance stays.
+- FAB stays (Android-native), colored by collection accent as now but per §3.4 (container = accent container is acceptable here as the screen's hero action).
+- Selection mode, drag-reorder, smart-filter variants unchanged behaviorally.
+
+**Verification:** the §9.2 + §9.3 checklists on device; Google Tasks/Calendar export + share still work; sub-task flows intact; save-on-back verified.
+
+---
+
+## 8. Phase 6 — Review flow
+
+[ReviewScreen.kt](../../app/src/main/java/org/muilab/notigpt/ui/review/ReviewScreen.kt), [ReviewCardStack.kt](../../app/src/main/java/org/muilab/notigpt/ui/review/component/ReviewCardStack.kt), [ReviewDetailSheet.kt](../../app/src/main/java/org/muilab/notigpt/ui/review/component/ReviewDetailSheet.kt):
+- Stack mechanics stay; swap `tween` fly-off/settle for `MotionSpecs.flyOff`/`settle` springs; add `Haptics.thresholdCross` when drag crosses commit threshold and `commitSwipe` on commit. Replace `LocalConfiguration.screenWidthDp` with `BoxWithConstraints`/`onSizeChanged` width.
+- Card: `shapes.extraLarge`, neutral surface, kill the 1 dp outline+shadow combo (pick shadow only, 2–4 dp); APPROVE/REJECT stamps keep semantic colors.
+- Bottom bar: reject/approve `FilledIconButton`s grow slightly (56 dp) with spring press feedback; "Approve all" stays a `TextButton` between them.
+- Detail `ModalBottomSheet` restyle per tokens; approve/reject actions inside it stay.
+- Empty state + filter chips per shared components.
+
+**Verification:** §9.4 checklist; undo snackbar works for both approve and reject; revert-on-reject for Updated items re-verified.
+
+---
+
+## 9. Feature Preservation Contract (binding for every phase)
+
+Every item below must work after each phase that touches its surface. Interaction *style* may change (e.g. dialog → sheet); capability may not disappear.
+
+### 9.1 NotiCard
+| Feature | Current entry point |
+|---|---|
+| Open notification's content intent + mark accessed/dismissed | tap card (`accessAndDismissNotification`) |
+| Archive card | horizontal swipe (direction per Settings), full card surface minus expand/pin buttons |
+| Reveal background actions: hide-actions, extract task | partial swipe |
+| Pin / Unpin | overlay pin button; also in options menu |
+| Expand / collapse records | drag the expand chevron (anchored drag + fling) or tap it |
+| Summary ↔ latest-record title swap at collapse threshold | automatic |
+| Options: Pin/Unpin, Extract task, Create scheduled reminder | long-press → dialog (→ sheet in §6.2) |
+| Reorder in sorting mode via drag handle (long-press) | sorting mode drag handle |
+| Sort-position highlight | thicker border (→ new highlight §6.1) |
+| Multi-record expanded list w/ per-record display | expansion area |
+| Swipe direction setting honored | Settings → swipeDeleteLeft |
+
+### 9.2 ReminderCard (Task/Keep)
+Complete (checkbox) / Archive (keep) toggle with haptics · expand/collapse content (chevron) · title strikethrough when completed · New/Updated badge until acknowledged · DueChip deadline urgency / "no deadline" text · content preview 2-line cap · LLM action buttons (link/copy chips, horizontal scroll) · inline sub-task list (toggle/click/edit/delete/export each sub-task) · do-date bottom button + picker (concrete date / Someday / clear; 09:00 default, preserves time-of-day) · star toggle · create scheduled reminder · export chooser (Google Tasks / Calendar) · delete (direct for new-like, confirm dialog otherwise) · long-press feedback flow · selection mode (checkbox, selected border) · left accent bar per section · open detail on tap.
+
+### 9.3 Detail editor
+Editable title · type toggle Task/Keep (FilterChips) · completed checkbox · deadline date+time pickers · do-date date+time + Someday chip + clear · note editor · LLM action chips · sub-tasks section (add/toggle/edit/delete/export) · create scheduled reminder chip · export Google Tasks / Google Calendar chips (+ sign-in flow when signed out) · share · change history section · related notifications (expandable, loading state, open-notification buttons, surrounding context load) · regenerate (⋮) · delete (⋮) · acknowledge-review · save-on-back (system back and arrow).
+
+### 9.4 Review flow
+Swipe right approve / left reject (reject NEW = soft delete; reject UPDATED = revert pending LLM edit) · tap opens detail sheet with approve/reject · filter chips (All / new-tasks / updated-tasks / new-keeps / updated-keeps, count labels, only non-zero shown) · bottom bar reject / approve-all / approve · undo snackbar (single step) · change-summary line on Updated cards · stacked depth preview (3 cards) · empty state.
+
+### 9.5 Screen-level
+Top-bar search (History, Reminders lists, NotiList, SavedList) · clear-all (NotiList, scoped, pinned excluded) · time-window chips (All/24h) · create-reminder-from-notification (records snapshot) · scheduled reminders: mark-seen, reschedule, cancel · history: grouped/timeline modes, copy, manual extract · preference chat: full flow incl. proposed-action cards, conflicts banner, active-preferences panel, user-context panel · settings: dynamic color toggle (activity recreate), swipe direction, extraction language picker w/ search, data export w/ options · sign-in screen · dev/user control panels.
+
+---
+
+## 10. Open item (needs a product decision, not blocking)
+
+**Scheduled (alarm) reminders on Home.** User is unsure whether these are primary-but-intrusive or secondary. Low-risk proposal to implement behind the decision: when `dueUnseenReminderCount > 0`, show a slim tappable strip on Home between the Review row and Notifications ("N reminders due", `dueSoonContainer` accent per §3.4 accent rules) → opens the Reminders screen. Zero cost when count is 0. **Ask the user before building; skip otherwise.**
+
+---
+
+## 11. Execution order, sizing, and verification
+
+| Phase | Scope | Size | Gate |
+|---|---|---|---|
+| 1 | Foundations: shapes, dimens, type rules, color policy plumbing, edge-to-edge+splash, motion+haptics helpers, snackbar bus | L | build+tests; dark-launch check; no white flash |
+| 2 | Shell: transitions, predictive back, LargeTopAppBar, drawer, search restyle | M | all-destination nav sweep; drawer gesture regression |
+| 3 | Home restyle | M | counts/nav sweep, 3 theme modes |
+| 4 | NotiCard + category/history | L | §9.1 + §9.5 device pass; slow-swipe regression |
+| 5 | Saved items: 7.0 split (own PR) → card + detail + list restyle | XL | §9.2/§9.3 device pass; export flows live |
+| 6 | Review flow | M | §9.4 device pass |
+| 7 | Settings rebuild (ListItem groups), Preferences chat restyle, ScheduledReminders restyle, SignIn polish, EmptyState/DueChip final pass | M | §9.5 remainder |
+
+Rules for the executor:
+- One phase per PR (Phase 5 = two PRs: split, then restyle). Build + `testDebugUnitTest` per PR (JBR `JAVA_HOME` per project memory).
+- After each phase, run the app and exercise the phase's §9 checklist on device/emulator — gesture code cannot be verified by compilation.
+- Never edit: `NotiCardSwipe.kt` intent math, drawer `gesturesEnabled` logic, ViewModel/repository business logic (UI-event plumbing additions are fine), the n8n contract, DB layer.
+- If an alpha `material3` API needed for a restyle is broken/missing, fall back to the stable-API equivalent and note it in the PR description; never downgrade the library mid-plan.
+- Strings: every new user-visible string goes to `strings.xml` + `values-zh-rTW/strings.xml`.
+
+---
+
+## 12. Explicit non-goals
+
+- No bottom navigation bar; no Navigation-Compose migration (ad-hoc back stack is settled).
+- No iOS control mimicry (no Cupertino switches, no centered iOS titles, no swipe-back-from-edge custom nav).
+- No feature additions beyond §10 (if approved) and undo-on-clear-all (§6.5).
+- No changes to extraction pipeline, sync, notifications listener, or data model.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ secrets-gradle-plugin = "2.0.1"
 
 # AndroidX versions
 core-ktx = "1.18.0"
+core-splashscreen = "1.0.1"
 lifecycle-runtime-ktx = "2.10.0"
 activity-compose = "1.13.0"
 compose-bom = "2026.05.01"
@@ -58,6 +59,7 @@ grpc = "1.81.0"
 # AndroidX
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
+core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
 constraintlayout-compose = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayout-compose" }


### PR DESCRIPTION
## Summary

Ground-up visual refresh across the app, built on a shared design-token foundation (color, shape, motion, type, dimens) rather than one-off per-screen tweaks. Direction is Android-native with Apple-level restraint, following the zero-feature-loss contract in docs/plans/ui-refinement-plan.md.

- **Phase 1** — Design-token foundations (`Color`, `Dimens`, `Motion`, `Shape`, `Type`) + platform hygiene cleanup
- **Phase 2** — App shell: transitions, predictive back gesture, large title, drawer
- **Phase 3** — Home overview restyle: neutral surfaces + colored discs
- **Phase 4** — Notification surfaces: `NotiCard` reskin, sheets, accessibility passes
- **Phase 5** — Saved-item cards: `ReminderCard` restyle
- **Phase 6** — Review flow: spring motion, haptics, cleaner cards
- **Phase 7** — Settings, scheduled reminders, sign-in, home strip, final token pass, plus a follow-up polish commit tokenizing history/scheduled card shapes

## Test plan

- [x] Build and run on device/emulator, verify no regressions in light/dark themes
- [x] Walk through home → notification history → review flow → settings → scheduled reminders → sign-in
- [x] Verify predictive back gesture and drawer transitions
- [x] Confirm accessibility labels/contrast on restyled `NotiCard` and `ReminderCard`
- [x] Spot-check zh-rTW strings render correctly